### PR TITLE
github action path 필터 수정

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -6,7 +6,7 @@ on:
       - main
       - dev
     paths:
-      - 'src/*'
+      - 'src/**'
     types:
       - opened
       - synchronize


### PR DESCRIPTION
# 개요

- github action path 필터를 src 하위의 모든 파일을 포함하도록 변경하는 PR

# 배경

- github action 이 src 하위의 파일에 대해서 동작하지 않음

# 변경된 점

- src/* -> src/**