### PR TITLE
메일 수신 시 뉴스레터 구독 기능 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG JAR_FILE=build/libs/*.jar
 ARG PROFILE=dev
 
 COPY ${JAR_FILE} /app.jar
-COPY src/main/resources/application-${PROFILE}.yml application.yml
+COPY src/main/resources/application-${PROFILE}.yml /config/application.yml
 
 ADD newrelic/newrelic.jar /usr/local/newrelic/newrelic.jar
 ADD newrelic/newrelic.yml /usr/local/newrelic/newrelic.yml

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/newzet/api/mail/business/MailServiceFacade.java
+++ b/src/main/java/com/newzet/api/mail/business/MailServiceFacade.java
@@ -1,0 +1,30 @@
+package com.newzet.api.mail.business;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newzet.api.newsletter.business.NewsletterService;
+import com.newzet.api.newsletter.domain.Newsletter;
+import com.newzet.api.subscription.business.service.SubscriptionService;
+import com.newzet.api.user.business.service.UserService;
+import com.newzet.api.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MailServiceFacade {
+
+	private final UserService userService;
+	private final NewsletterService newsletterService;
+	private final SubscriptionService subscriptionService;
+
+	public void processMail(String fromName, String fromDomain, String toDomain, String mailingList,
+		String htmlLink) {
+		User user = userService.getUserByEmail(toDomain);
+		Newsletter newsletter = newsletterService.findOrCreateNewsletter(fromName,
+			fromDomain, mailingList);
+		subscriptionService.addSubscription(user, newsletter);
+	}
+}

--- a/src/main/java/com/newzet/api/mail/presentation/MailController.java
+++ b/src/main/java/com/newzet/api/mail/presentation/MailController.java
@@ -1,0 +1,27 @@
+package com.newzet.api.mail.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.newzet.api.mail.business.MailServiceFacade;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/functions/v1/mail")
+public class MailController {
+
+	private final MailServiceFacade mailServiceFacade;
+
+	@PostMapping
+	public ResponseEntity<Object> receive(@RequestBody @Valid MailMetadataDto metadata) {
+		mailServiceFacade.processMail(metadata.getFromName(), metadata.getFromDomain(),
+			metadata.getToDomain(), metadata.getMailingList(), metadata.getHtmlLink());
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/newzet/api/mail/presentation/MailMetadataDto.java
+++ b/src/main/java/com/newzet/api/mail/presentation/MailMetadataDto.java
@@ -1,0 +1,17 @@
+package com.newzet.api.mail.presentation;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MailMetadataDto {
+	private final String fromName;
+	private final String fromDomain;
+	private final String toDomain;
+	private final String mailingList;
+	private final String htmlLink;
+}

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.newzet.api.common.cache.CacheUtil;
 import com.newzet.api.common.cache.LockFactory;
@@ -14,10 +15,9 @@ import com.newzet.api.newsletter.domain.Newsletter;
 import com.newzet.api.newsletter.domain.NewsletterStatus;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class NewsletterService {
 

--- a/src/main/java/com/newzet/api/user/business/service/UserService.java
+++ b/src/main/java/com/newzet/api/user/business/service/UserService.java
@@ -1,6 +1,7 @@
 package com.newzet.api.user.business.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.newzet.api.user.business.dto.UserEntityDto;
 import com.newzet.api.user.domain.User;
@@ -8,6 +9,7 @@ import com.newzet.api.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class UserService {
 


### PR DESCRIPTION
# 개요

- 메일 수신 시 뉴스레터 구독 기능 구현을 위한 PR

# 배경

- 메일 수신 수 뉴스레터 구독 여부를 확인해서 구독 목록에 추가해야 함.

# 변경된 점

- 메일 수신 endpoint 정의
- 메일 수신 시 user, newsletter 조회 후 subscription을 추가하는 로직을 mailServiceFacade에서 호출하도록 로직 구현