### PR TITLE
CI/CD 과정의 안전한 서버 배포를 위한 Graceful Shutdown 적용

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -54,8 +54,8 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t "$DOCKERHUB_USERNAME/newzet-apm:$IMAGE_TAG" .
-          docker push "$DOCKERHUB_USERNAME/newzet-apm:$IMAGE_TAG"
+          docker build -t "$DOCKERHUB_USERNAME/newzet-spring-server:$IMAGE_TAG" .
+          docker push "$DOCKERHUB_USERNAME/newzet-spring-server:$IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: Install jq

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ out/
 .secrets
 .env
 .env.prod
+.env.redis
 /dockercomposes/monitoring/newrelic-infra/newrelic-infra.yml
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,18 +3,18 @@ set -e
 
 cd /home/ubuntu/app
 
-docker-compose -f docker-compose.yml down || true
-
 aws s3 cp s3://newzet-config/.env .env
 echo "IMAGE_TAG=$1" >> .env
 echo "APP_VERSION=$2" >> .env
 
-docker-compose -f docker-compose.yml --env-file .env up -d
+PROJECT_NAME="newzet"
+docker-compose -p $PROJECT_NAME -f docker-compose.yml stop spring-server --timeout 60 || true
+docker-compose -p $PROJECT_NAME -f docker-compose.yml --env-file .env up -d
 
 timeout 60s bash -c "until curl -s http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'; do sleep 5; echo 'Waiting for health check...'; done"
 if [ $? -ne 0 ]; then
   echo "Health check failed"
-  docker-compose -f docker-compose.yml down
+  docker-compose -p $PROJECT_NAME -f docker-compose.yml stop spring-server
   exit 1
 fi
 

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:7.0.8-alpine
+    container_name: ${SPRING_REDIS_HOST}
+    command: redis-server --requirepass ${SPRING_REDIS_PASSWORD} --bind 0.0.0.0
+    ports:
+      - "6379:6379"
+    env_file:
+      - .env.redis
+    networks:
+      - newzet-network
+
+networks:
+  newzet-network:
+    driver: bridge

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - newzet-network
 
-  newzet-apm:
+  spring-server:
     build: .
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,7 @@
 version: '3.8'
 services:
-  redis:
-    image: redis:7.0.8-alpine
-    container_name: ${SPRING_REDIS_HOST}
-    command: redis-server --requirepass ${SPRING_REDIS_PASSWORD} --bind 0.0.0.0
-    ports:
-      - "6379:6379"
-    env_file:
-      - .env
-    networks:
-      - newzet-network
-
-  newzet-apm:
-    image: ${DOCKER_USERNAME}/newzet-apm:${IMAGE_TAG:-latest}
+  spring-server:
+    image: ${DOCKER_USERNAME}/newzet-spring-server:${IMAGE_TAG:-latest}
     ports:
       - "8080:8080"
     depends_on:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  lifecycle:
+    timeout-per-shutdown: 60s
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     username: ${DB_USERNAME}
@@ -38,6 +40,7 @@ info:
     version: ${APP_VERSION:latest}
 
 server:
+  shutdown: graceful
   tomcat:
     mbeanregistry:
       enabled: true


### PR DESCRIPTION
# 배경

- 이전에 수행한 배포가 테스트 중일 때, Canary 서버가 동작 중 다음 배포가 발생하면, 시간이 긴 작업의 경우에는 서버에서 처리하고 있는 요청이 강제 종료될 수 있는 문제 발생
- 현재의 배포 프로세스는 각 EC2 마다 별도의 캐시를 가져서 비효율적이고, 서버 CI/CD와 함께 redis도 같이 배포됨

# 변경된 점

- 서버에서 처리중인 요청을 다 처리하고 서버를 종료하도록 graceful shutdown 설정
- Redis 컨테이너를 기존 배포 프로세스에서 제외 후 별도 docker file 작성