### PR TITLE
fix: gitignore와 readme 수정 시 ci 수행하지 않도록 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - dev
-    paths:
-      - 'src/**'
     types:
       - opened
       - synchronize
@@ -17,6 +15,15 @@ jobs:
     steps:
       - name: get repository code
         uses: actions/checkout@v4
+
+      - name: Exit if only README.md and .gitignore changed
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          if ! git diff --name-only origin/${{ github.base_ref }}...HEAD \
+            | grep -v -E '^(README\.md|\.gitignore)$' \
+            | grep .; then
+            exit 0
+          fi
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
# 배경

- readme와 gitignore 파일을 수정시에도 pr merge 시에 ci를 필수로 요구하여 merge가 안되는 문제 발생

# 변경된 점

- readme와 gitignore 파일 수정 시에는 ci가 수행되지 않도록 변경
