### PR TITLE
Redis 서버 종료 시 500번 에러가 발생하는 이슈 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,6 @@ out/
 .env
 .env.dev
 .env.redis
+.env.redis.dev
 /dockercomposes/monitoring/newrelic-infra/newrelic-infra.yml
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ out/
 /newrelic
 .secrets
 .env
-.env.prod
+.env.dev
 .env.redis
 /dockercomposes/monitoring/newrelic-infra/newrelic-infra.yml
 

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -6,8 +6,6 @@ services:
     command: redis-server --requirepass ${SPRING_REDIS_PASSWORD} --bind 0.0.0.0
     ports:
       - "6379:6379"
-    env_file:
-      - .env.redis
     networks:
       - newzet-network
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,22 +1,9 @@
 version: '3.8'
 services:
-  redis:
-    image: redis:7.0.8-alpine
-    container_name: ${SPRING_REDIS_HOST}
-    command: redis-server --requirepass ${SPRING_REDIS_PASSWORD} --bind 0.0.0.0
-    ports:
-      - "6379:6379"
-    env_file:
-      - .env
-    networks:
-      - newzet-network
-
   spring-server:
     build: .
     ports:
       - "8080:8080"
-    depends_on:
-      - redis
     env_file:
       - .env
     networks:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - .env
+      - .env.dev
     networks:
       - newzet-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: ${DOCKER_USERNAME}/newzet-spring-server:${IMAGE_TAG:-latest}
     ports:
       - "8080:8080"
-    depends_on:
-      - redis
     env_file:
       - .env
     networks:

--- a/src/main/java/com/newzet/api/common/cache/RedisLockFactory.java
+++ b/src/main/java/com/newzet/api/common/cache/RedisLockFactory.java
@@ -9,7 +9,9 @@ import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisLockFactory implements LockFactory {
@@ -26,13 +28,21 @@ public class RedisLockFactory implements LockFactory {
 			return acquired ? Optional.of(lock) : Optional.empty();
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
+			log.warn("Redis lock 획득 중 interrupt 발생, key: {}", lockKey);
+			return Optional.empty();
+		} catch (Exception e) {
+			log.error("Redis lock 획득 실패, key: {}, error: {}", lockKey, e.getMessage());
 			return Optional.empty();
 		}
 	}
 
 	@Override
 	public void unlock(Lock lock) {
-		lock.unlock();
+		try{
+			lock.unlock();
+		} catch(Exception e) {
+			log.error("Redis lock 해제 실패, error {}", e.getMessage());
+		}
 	}
 }
 

--- a/src/main/java/com/newzet/api/common/cache/RedisUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/RedisUtil.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Component;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisUtil implements CacheUtil {
@@ -20,18 +22,35 @@ public class RedisUtil implements CacheUtil {
 
 	@Override
 	public <T> Optional<T> get(String key, Class<T> classType) {
-		String cachedValue = redisTemplate.opsForValue().get(key);
-		return objectMapper.deserialize(cachedValue, classType);
+		try{
+			String cachedValue = redisTemplate.opsForValue().get(key);
+			return objectMapper.deserialize(cachedValue, classType);
+		}catch(Exception e) {
+			log.error("Redis 에서 key 가져오기 실패, key: {}, error: {}", key, e.getMessage());
+			return Optional.empty();
+		}
+
 	}
 
 	@Override
 	public Boolean set(String key, Object object, long ttl) {
-		String value = objectMapper.serialize(object);
-		return redisTemplate.opsForValue().setIfAbsent(key, value, ttl, TIME_UNIT);
+		try{
+			String value = objectMapper.serialize(object);
+			return redisTemplate.opsForValue().setIfAbsent(key, value, ttl, TIME_UNIT);
+		} catch (Exception e) {
+			log.error("Redis 값 저장 실패, key: {}, error: {}", key, e.getMessage());
+			return false;
+		}
+
 	}
 
 	@Override
 	public void deleteAllKeys() {
-		redisTemplate.delete(redisTemplate.keys("*"));
+		try{
+			redisTemplate.delete(redisTemplate.keys("*"));
+		} catch(Exception e) {
+			log.error("Redis에서 key 모두 삭제 실패, error: {}", e.getMessage());
+		}
+
 	}
 }

--- a/src/main/java/com/newzet/api/config/RedisConfig.java
+++ b/src/main/java/com/newzet/api/config/RedisConfig.java
@@ -1,14 +1,20 @@
 package com.newzet.api.config;
 
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
 
 @Configuration
 public class RedisConfig {
@@ -24,9 +30,18 @@ public class RedisConfig {
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
-		config.setPassword(RedisPassword.of(password));
-		return new LettuceConnectionFactory(config);
+		RedisStandaloneConfiguration serverConfig = new RedisStandaloneConfiguration(host, port);
+		serverConfig.setPassword(RedisPassword.of(password));
+
+		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+			.commandTimeout(Duration.ofMillis(500))
+			.clientOptions(ClientOptions.builder()
+				.socketOptions(SocketOptions.builder().connectTimeout(Duration.ofMillis(1000)).build())
+				.disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
+				.build())
+			.build();
+
+		return new LettuceConnectionFactory(serverConfig, clientConfig);
 	}
 
 	@Bean

--- a/src/main/java/com/newzet/api/config/RedissonConfig.java
+++ b/src/main/java/com/newzet/api/config/RedissonConfig.java
@@ -26,7 +26,12 @@ public class RedissonConfig {
 		Config config = new Config();
 		config.useSingleServer()
 			.setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort)
-			.setPassword(password);
+			.setPassword(password)
+			.setConnectTimeout(1000)
+			.setTimeout(500)
+			.setRetryAttempts(1)
+			.setRetryInterval(200)
+			.setPingConnectionInterval(30000);
 
 		return Redisson.create(config);
 	}

--- a/src/main/java/com/newzet/api/config/RedissonConfig.java
+++ b/src/main/java/com/newzet/api/config/RedissonConfig.java
@@ -27,6 +27,7 @@ public class RedissonConfig {
 		config.useSingleServer()
 			.setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort)
 			.setPassword(password)
+			.setDnsMonitoringInterval(30000)
 			.setConnectTimeout(1000)
 			.setTimeout(500)
 			.setRetryAttempts(1)

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
@@ -15,7 +15,9 @@ import com.newzet.api.newsletter.domain.Newsletter;
 import com.newzet.api.newsletter.domain.NewsletterStatus;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -43,29 +45,37 @@ public class NewsletterService {
 
 	private Newsletter findOrCreateByDomainOrMailingListWithLock(String name, String domain,
 		String mailingList) {
-		Lock lock = lockFactory.tryLock(CACHE_DOMAIN_PREFIX + ":" + domain,
-			CACHE_LOCK_WAIT_TIME, CACHE_LOCK_LEASE_TIME).orElseThrow(() ->
-			new LockAcquisitionException(this.getClass().getSimpleName() + "#" +
-				Thread.currentThread().getStackTrace()[2].getMethodName()));
+		Optional<Lock> lockOptional = lockFactory.tryLock(CACHE_DOMAIN_PREFIX + ":" + domain, CACHE_LOCK_WAIT_TIME, CACHE_LOCK_LEASE_TIME);
+
+		if (lockOptional.isEmpty()) {
+			log.warn("lock 획득 실패, domain: {}", domain);
+			return findOrCreateByDomainOrMailingListInDatabase(name, domain,
+				mailingList);
+		}
+
+		Lock lock = lockOptional.get();
 		try {
 			Optional<Newsletter> cachedNewsletter = findByDomainOnCache(domain);
 			if (cachedNewsletter.isPresent()) {
 				return cachedNewsletter.get();
 			}
 
-			NewsletterEntityDto newsletterEntityDto = newsletterRepository
-				.findByDomainOrMailingList(domain, mailingList)
-				.orElseGet(() -> newsletterRepository
-					.save(name, domain, mailingList, NewsletterStatus.UNREGISTERED.name()));
-
-			Newsletter newsletter = Newsletter.create(newsletterEntityDto.getId(),
-				newsletterEntityDto.getName(), newsletterEntityDto.getDomain(),
-				newsletterEntityDto.getMailingList(), newsletterEntityDto.getStatus());
-
+			Newsletter newsletter =  findOrCreateByDomainOrMailingListInDatabase(name, domain, mailingList);
 			cacheUtil.set(CACHE_DOMAIN_PREFIX + domain, newsletter.toCacheDto(), CACHE_DURATION);
 			return newsletter;
 		} finally {
 			lockFactory.unlock(lock);
 		}
+	}
+
+	private Newsletter findOrCreateByDomainOrMailingListInDatabase(String name, String domain, String mailingList) {
+		NewsletterEntityDto newsletterEntityDto = newsletterRepository
+			.findByDomainOrMailingList(domain, mailingList)
+			.orElseGet(() -> newsletterRepository
+				.save(name, domain, mailingList, NewsletterStatus.UNREGISTERED.name()));
+
+		return Newsletter.create(newsletterEntityDto.getId(),
+			newsletterEntityDto.getName(), newsletterEntityDto.getDomain(),
+			newsletterEntityDto.getMailingList(), newsletterEntityDto.getStatus());
 	}
 }

--- a/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
+++ b/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
@@ -114,10 +114,18 @@ class NewsletterServiceTest {
 		when(cacheUtil.get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class)).thenReturn(
 			Optional.empty());
 		when(lockFactory.tryLock(any(), anyLong(), anyLong())).thenReturn(Optional.empty());
+		when(newsletterRepository.findByDomainOrMailingList(domain, mailingList)).thenReturn(
+			Optional.of(entityDto));
 
-		//When, Then
-		assertThrows(LockAcquisitionException.class,
-			() -> newsletterService.findOrCreateNewsletter(name, domain, mailingList));
+		// When
+		Newsletter newsletter = newsletterService.findOrCreateNewsletter(name, domain, mailingList);
+
+		// Then
+		verifyValue(newsletter);
+		verify(cacheUtil, times(1)).get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class);
+		verify(newsletterRepository, times(1)).findByDomainOrMailingList(domain, mailingList);
+		verify(cacheUtil, never()).set(eq(CACHE_DOMAIN_PREFIX + domain), any(), anyLong());
+		verify(lockFactory, never()).unlock(lock);
 	}
 
 	private void verifyValue(Newsletter newsletter) {


### PR DESCRIPTION
# 개요

- Redis 서버 종료 시 500번 에러가 발생하는 이슈 해결을 위한 PR

# 배경

- spring 서버와 redis가 연결되어 있고, db 조회 전 redis를 먼저 조회하는 구조로 되어있음
- 동시성 제어를 위해 redisson 분산 락을 사용함.
- 이떄 갑작스럽게 redis 서버가 종료되면 서버에서 DB를 조회해서 데이터를 리턴해야하는데 예외처리가 없어서 500 에러를 내뿜음

# 변경된 점

- redis 서버 종료 시에는 DB에서 데이터를 조회해서 반환하도록 변경
- redis 데이터 조회 및 lock 획득 응답 timeout 조절
- redis connection 끊겼을 때, 재시도 횟수, monitoring 횟수 조절