### PR TITLE
Redis 서버 다운 시 로컬 캐시로 전환을 위해 HybridCacheUtil을 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.43.0'
 
+    // Caffeine 추가
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
     // test container
     testImplementation 'org.testcontainers:testcontainers:1.20.5'
     testImplementation 'org.testcontainers:junit-jupiter:1.20.5'

--- a/src/main/java/com/newzet/api/common/cache/CacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/CacheUtil.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 public interface CacheUtil {
 	public <T> Optional<T> get(String key, Class<T> classType);
 
-	public Boolean set(String key, Object object, long ttl);
+	public <T> Boolean set(String key, T object, long ttl);
 
 	public void deleteAllKeys();
 }

--- a/src/main/java/com/newzet/api/common/cache/CacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/CacheUtil.java
@@ -6,6 +6,4 @@ public interface CacheUtil {
 	public <T> Optional<T> get(String key, Class<T> classType);
 
 	public <T> Boolean set(String key, T object, long ttl);
-
-	public void deleteAllKeys();
 }

--- a/src/main/java/com/newzet/api/common/cache/CacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/CacheUtil.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 public interface CacheUtil {
 	public <T> Optional<T> get(String key, Class<T> classType);
 
-	public <T> Boolean set(String key, T object, long ttl);
+	public <T> void set(String key, T object, long ttl);
 }

--- a/src/main/java/com/newzet/api/common/cache/HybridCacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/HybridCacheUtil.java
@@ -18,25 +18,25 @@ import lombok.extern.slf4j.Slf4j;
 @Primary
 @Component
 @RequiredArgsConstructor
-public class HybridCacheUtil implements CacheUtil{
+public class HybridCacheUtil implements CacheUtil {
 	private final RedisUtil redisUtil;
 	private final LocalCacheUtil localCacheUtil;
 
 	@Override
 	public <T> Optional<T> get(String key, Class<T> classType) {
-		try{
+		try {
 			return redisUtil.get(key, classType);
-		} catch(RedisServerException e) {
+		} catch (RedisServerException e) {
 			return localCacheUtil.get(key, classType);
 		}
 	}
 
 	@Override
-	public <T> Boolean set(String key, T object, long ttl) {
-		try{
-			return redisUtil.set(key, object, ttl);
-		} catch(CacheException e) {
-			return localCacheUtil.set(key, object, ttl);
+	public <T> void set(String key, T object, long ttl) {
+		try {
+			redisUtil.set(key, object, ttl);
+		} catch (CacheException e) {
+			localCacheUtil.set(key, object, ttl);
 		}
 	}
 }

--- a/src/main/java/com/newzet/api/common/cache/HybridCacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/HybridCacheUtil.java
@@ -2,8 +2,6 @@ package com.newzet.api.common.cache;
 
 import java.util.Optional;
 
-import javax.cache.CacheException;
-
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -35,7 +33,7 @@ public class HybridCacheUtil implements CacheUtil {
 	public <T> void set(String key, T object, long ttl) {
 		try {
 			redisUtil.set(key, object, ttl);
-		} catch (CacheException e) {
+		} catch (RedisServerException e) {
 			localCacheUtil.set(key, object, ttl);
 		}
 	}

--- a/src/main/java/com/newzet/api/common/cache/HybridCacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/HybridCacheUtil.java
@@ -1,0 +1,42 @@
+package com.newzet.api.common.cache;
+
+import java.util.Optional;
+
+import javax.cache.CacheException;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import com.newzet.api.common.cache.local.LocalCacheUtil;
+import com.newzet.api.common.cache.redis.RedisServerException;
+import com.newzet.api.common.cache.redis.RedisUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Primary
+@Component
+@RequiredArgsConstructor
+public class HybridCacheUtil implements CacheUtil{
+	private final RedisUtil redisUtil;
+	private final LocalCacheUtil localCacheUtil;
+
+	@Override
+	public <T> Optional<T> get(String key, Class<T> classType) {
+		try{
+			return redisUtil.get(key, classType);
+		} catch(RedisServerException e) {
+			return localCacheUtil.get(key, classType);
+		}
+	}
+
+	@Override
+	public <T> Boolean set(String key, T object, long ttl) {
+		try{
+			return redisUtil.set(key, object, ttl);
+		} catch(CacheException e) {
+			return localCacheUtil.set(key, object, ttl);
+		}
+	}
+}

--- a/src/main/java/com/newzet/api/common/cache/RedisUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/RedisUtil.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import com.newzet.api.common.cache.exception.RedisServerException;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -26,8 +27,8 @@ public class RedisUtil implements CacheUtil {
 			String cachedValue = redisTemplate.opsForValue().get(key);
 			return objectMapper.deserialize(cachedValue, classType);
 		}catch(Exception e) {
-			log.error("Redis 에서 key 가져오기 실패, key: {}, error: {}", key, e.getMessage());
-			return Optional.empty();
+			log.error("[RedisUtil]: Redis 에서 key 가져오기 실패, key: {}, error: {}", key, e.getMessage());
+			throw new RedisServerException();
 		}
 
 	}
@@ -38,10 +39,9 @@ public class RedisUtil implements CacheUtil {
 			String value = objectMapper.serialize(object);
 			return redisTemplate.opsForValue().setIfAbsent(key, value, ttl, TIME_UNIT);
 		} catch (Exception e) {
-			log.error("Redis 값 저장 실패, key: {}, error: {}", key, e.getMessage());
-			return false;
+			log.error("[RedisUtil]: Redis 값 저장 실패, key: {}, error: {}", key, e.getMessage());
+			throw new RedisServerException();
 		}
-
 	}
 
 	@Override
@@ -49,7 +49,8 @@ public class RedisUtil implements CacheUtil {
 		try{
 			redisTemplate.delete(redisTemplate.keys("*"));
 		} catch(Exception e) {
-			log.error("Redis에서 key 모두 삭제 실패, error: {}", e.getMessage());
+			log.error("[RedisUtil]: Redis에서 key 모두 삭제 실패, error: {}", e.getMessage());
+			throw new RedisServerException();
 		}
 
 	}

--- a/src/main/java/com/newzet/api/common/cache/exception/RedisServerException.java
+++ b/src/main/java/com/newzet/api/common/cache/exception/RedisServerException.java
@@ -1,0 +1,9 @@
+package com.newzet.api.common.cache.exception;
+
+import org.springframework.data.redis.connection.RedisServer;
+
+public class RedisServerException extends RuntimeException {
+	public RedisServerException() {
+		super();
+	}
+}

--- a/src/main/java/com/newzet/api/common/cache/local/CacheEntry.java
+++ b/src/main/java/com/newzet/api/common/cache/local/CacheEntry.java
@@ -1,0 +1,19 @@
+package com.newzet.api.common.cache.local;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class CacheEntry<T> {
+	@Getter
+	private final T value;
+	private final long expireTime;
+
+	public CacheEntry(T value, long ttlMillis) {
+		this.value = value;
+		this.expireTime = System.currentTimeMillis() + ttlMillis;
+	}
+
+	public boolean isExpired() {
+		return System.currentTimeMillis() > expireTime;
+	}
+}

--- a/src/main/java/com/newzet/api/common/cache/local/LocalCacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/local/LocalCacheUtil.java
@@ -1,0 +1,61 @@
+package com.newzet.api.common.cache.local;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.newzet.api.common.cache.CacheUtil;
+import com.querydsl.codegen.utils.model.ClassType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class LocalCacheUtil implements CacheUtil {
+
+	private final Cache<String, CacheEntry<?>> cache;
+
+	public LocalCacheUtil() {
+		this.cache = Caffeine.newBuilder()
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.maximumSize(10_000)
+			.build();
+	}
+
+	@Override
+	public <T> Optional<T> get(String key, Class<T> classType) {
+		CacheEntry<?> entry = cache.getIfPresent(key);
+		if (entry == null) {
+			return Optional.empty();
+		}
+
+		if (entry.isExpired()) {
+			cache.invalidate(key);
+			return Optional.empty();
+		}
+
+		try{
+			return Optional.of(classType.cast(entry.getValue()));
+		}catch(ClassCastException e) {
+			log.error("[LocalCacheUtil]: Local Cache에서 값 가져오기 실패, key: {}, error: {}", key,
+				e.getMessage());
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public <T> Boolean set(String key, T object, long ttl) {
+		CacheEntry<?> previous = cache.getIfPresent(key);
+		cache.put(key, new CacheEntry<>(object, ttl));
+		return previous != null;
+	}
+
+	@Override
+	public void deleteAllKeys() {
+		cache.invalidateAll();
+	}
+}

--- a/src/main/java/com/newzet/api/common/cache/local/LocalCacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/local/LocalCacheUtil.java
@@ -53,9 +53,4 @@ public class LocalCacheUtil implements CacheUtil {
 		cache.put(key, new CacheEntry<>(object, ttl));
 		return previous != null;
 	}
-
-	@Override
-	public void deleteAllKeys() {
-		cache.invalidateAll();
-	}
 }

--- a/src/main/java/com/newzet/api/common/cache/local/LocalCacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/local/LocalCacheUtil.java
@@ -8,9 +8,7 @@ import org.springframework.stereotype.Component;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.newzet.api.common.cache.CacheUtil;
-import com.querydsl.codegen.utils.model.ClassType;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -38,9 +36,9 @@ public class LocalCacheUtil implements CacheUtil {
 			return Optional.empty();
 		}
 
-		try{
+		try {
 			return Optional.of(classType.cast(entry.getValue()));
-		}catch(ClassCastException e) {
+		} catch (ClassCastException e) {
 			log.error("[LocalCacheUtil]: Local Cache에서 값 가져오기 실패, key: {}, error: {}", key,
 				e.getMessage());
 			return Optional.empty();
@@ -48,9 +46,7 @@ public class LocalCacheUtil implements CacheUtil {
 	}
 
 	@Override
-	public <T> Boolean set(String key, T object, long ttl) {
-		CacheEntry<?> previous = cache.getIfPresent(key);
+	public <T> void set(String key, T object, long ttl) {
 		cache.put(key, new CacheEntry<>(object, ttl));
-		return previous != null;
 	}
 }

--- a/src/main/java/com/newzet/api/common/cache/redis/RedisServerException.java
+++ b/src/main/java/com/newzet/api/common/cache/redis/RedisServerException.java
@@ -1,6 +1,4 @@
-package com.newzet.api.common.cache.exception;
-
-import org.springframework.data.redis.connection.RedisServer;
+package com.newzet.api.common.cache.redis;
 
 public class RedisServerException extends RuntimeException {
 	public RedisServerException() {

--- a/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
@@ -23,10 +23,10 @@ public class RedisUtil implements CacheUtil {
 
 	@Override
 	public <T> Optional<T> get(String key, Class<T> classType) {
-		try{
+		try {
 			String cachedValue = redisTemplate.opsForValue().get(key);
 			return objectMapper.deserialize(cachedValue, classType);
-		}catch(Exception e) {
+		} catch (Exception e) {
 			log.error("[RedisUtil]: Redis 에서 key 가져오기 실패, key: {}, error: {}", key, e.getMessage());
 			throw new RedisServerException();
 		}
@@ -34,10 +34,10 @@ public class RedisUtil implements CacheUtil {
 	}
 
 	@Override
-	public <T> Boolean set(String key, T object, long ttl) {
-		try{
+	public <T> void set(String key, T object, long ttl) {
+		try {
 			String value = objectMapper.serialize(object);
-			return redisTemplate.opsForValue().setIfAbsent(key, value, ttl, TIME_UNIT);
+			redisTemplate.opsForValue().set(key, value, ttl, TIME_UNIT);
 		} catch (Exception e) {
 			log.error("[RedisUtil]: Redis 값 저장 실패, key: {}, error: {}", key, e.getMessage());
 			throw new RedisServerException();

--- a/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
@@ -1,4 +1,4 @@
-package com.newzet.api.common.cache;
+package com.newzet.api.common.cache.redis;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import com.newzet.api.common.cache.exception.RedisServerException;
+import com.newzet.api.common.cache.CacheUtil;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
@@ -34,7 +34,7 @@ public class RedisUtil implements CacheUtil {
 	}
 
 	@Override
-	public Boolean set(String key, Object object, long ttl) {
+	public <T> Boolean set(String key, T object, long ttl) {
 		try{
 			String value = objectMapper.serialize(object);
 			return redisTemplate.opsForValue().setIfAbsent(key, value, ttl, TIME_UNIT);

--- a/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
@@ -43,15 +43,4 @@ public class RedisUtil implements CacheUtil {
 			throw new RedisServerException();
 		}
 	}
-
-	@Override
-	public void deleteAllKeys() {
-		try{
-			redisTemplate.delete(redisTemplate.keys("*"));
-		} catch(Exception e) {
-			log.error("[RedisUtil]: Redis에서 key 모두 삭제 실패, error: {}", e.getMessage());
-			throw new RedisServerException();
-		}
-
-	}
 }

--- a/src/main/java/com/newzet/api/common/lock/exception/LockAcquisitionException.java
+++ b/src/main/java/com/newzet/api/common/lock/exception/LockAcquisitionException.java
@@ -1,0 +1,7 @@
+package com.newzet.api.common.lock.exception;
+
+public class LockAcquisitionException extends RuntimeException {
+	public LockAcquisitionException() {
+		super();
+	}
+}

--- a/src/main/java/com/newzet/api/common/lock/exception/RedisLockAcquisitionException.java
+++ b/src/main/java/com/newzet/api/common/lock/exception/RedisLockAcquisitionException.java
@@ -1,9 +1,4 @@
 package com.newzet.api.common.lock.exception;
 
-import lombok.extern.slf4j.Slf4j;
-
-public class RedisLockAcquisitionException extends RuntimeException {
-	public RedisLockAcquisitionException() {
-		super();
-	}
+public class RedisLockAcquisitionException extends LockAcquisitionException {
 }

--- a/src/main/java/com/newzet/api/common/lock/local/LocalLockFactory.java
+++ b/src/main/java/com/newzet/api/common/lock/local/LocalLockFactory.java
@@ -34,8 +34,8 @@ public class LocalLockFactory implements LockFactory {
 	public void unlock(Lock lock) {
 		try {
 			lock.unlock();
-			locks.remove(((LocalLock) lock).getLockKey());
-		}  catch(Exception e) {
+			locks.remove(((LocalLock)lock).getLockKey());
+		} catch (Exception e) {
 			log.error("[LocalLockFactory]: Local lock 해제 실패, error {}", e.getMessage());
 		}
 	}

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.newzet.api.common.cache.CacheUtil;
 import com.newzet.api.common.lock.LockFactory;
+import com.newzet.api.common.lock.exception.LockAcquisitionException;
 import com.newzet.api.newsletter.business.dto.NewsletterCacheDto;
 import com.newzet.api.newsletter.business.dto.NewsletterEntityDto;
 import com.newzet.api.newsletter.domain.Newsletter;
@@ -44,12 +45,12 @@ public class NewsletterService {
 
 	private Newsletter findOrCreateByDomainOrMailingListWithLock(String name, String domain,
 		String mailingList) {
-		Optional<Lock> lockOptional = lockFactory.tryLock(CACHE_DOMAIN_PREFIX + ":" + domain, CACHE_LOCK_WAIT_TIME, CACHE_LOCK_LEASE_TIME);
+		Optional<Lock> lockOptional = lockFactory.tryLock(CACHE_DOMAIN_PREFIX + ":" + domain,
+			CACHE_LOCK_WAIT_TIME, CACHE_LOCK_LEASE_TIME);
 
 		if (lockOptional.isEmpty()) {
-			log.warn("lock 획득 실패, domain: {}", domain);
-			return findOrCreateByDomainOrMailingListInDatabase(name, domain,
-				mailingList);
+			log.warn("[NewsletterService] lock 획득 실패, domain: {}", domain);
+			throw new LockAcquisitionException();
 		}
 
 		Lock lock = lockOptional.get();
@@ -59,7 +60,8 @@ public class NewsletterService {
 				return cachedNewsletter.get();
 			}
 
-			Newsletter newsletter =  findOrCreateByDomainOrMailingListInDatabase(name, domain, mailingList);
+			Newsletter newsletter = findOrCreateByDomainOrMailingListInDatabase(name, domain,
+				mailingList);
 			cacheUtil.set(CACHE_DOMAIN_PREFIX + domain, newsletter.toCacheDto(), CACHE_DURATION);
 			return newsletter;
 		} finally {
@@ -67,7 +69,8 @@ public class NewsletterService {
 		}
 	}
 
-	private Newsletter findOrCreateByDomainOrMailingListInDatabase(String name, String domain, String mailingList) {
+	private Newsletter findOrCreateByDomainOrMailingListInDatabase(String name, String domain,
+		String mailingList) {
 		NewsletterEntityDto newsletterEntityDto = newsletterRepository
 			.findByDomainOrMailingList(domain, mailingList)
 			.orElseGet(() -> newsletterRepository

--- a/src/test/java/com/newzet/api/common/cache/CacheEntryTest.java
+++ b/src/test/java/com/newzet/api/common/cache/CacheEntryTest.java
@@ -1,0 +1,30 @@
+package com.newzet.api.common.cache;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.newzet.api.common.cache.local.CacheEntry;
+
+public class CacheEntryTest {
+
+	@Test
+	public void isExpired_whenBeforeTTL_returnFalse() {
+		//When
+		CacheEntry<String> entry = new CacheEntry<>("test", 1000);
+		boolean isExpired = entry.isExpired();
+
+		//Then
+		Assertions.assertFalse(isExpired);
+	}
+
+	@Test
+	public void isExpired_whenAfterTTL_returnTrue() throws InterruptedException {
+		//When
+		CacheEntry<String> entry = new CacheEntry<>("test", 100);
+		Thread.sleep(110);
+		boolean isExpired = entry.isExpired();
+
+		//Then
+		Assertions.assertTrue(isExpired);
+	}
+}

--- a/src/test/java/com/newzet/api/common/cache/HybridCacheUtilTest.java
+++ b/src/test/java/com/newzet/api/common/cache/HybridCacheUtilTest.java
@@ -1,0 +1,91 @@
+package com.newzet.api.common.cache;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.newzet.api.common.cache.local.LocalCacheUtil;
+import com.newzet.api.common.cache.redis.RedisServerException;
+import com.newzet.api.common.cache.redis.RedisUtil;
+
+@ExtendWith(MockitoExtension.class)
+public class HybridCacheUtilTest {
+	@Mock
+	RedisUtil redisUtil;
+
+	@Mock
+	LocalCacheUtil localCacheUtil;
+
+	@InjectMocks
+	HybridCacheUtil hybridCacheUtil;
+
+	@Test
+	void get_whenRedisLive_returnRedisValue() {
+		//Given
+		String key = "testKey";
+		String value = "testValue";
+		when(redisUtil.get(key, String.class)).thenReturn(Optional.of(value));
+
+		//When
+		Optional<String> result = hybridCacheUtil.get(key, String.class);
+
+		//Then
+		assertTrue(result.isPresent());
+		assertEquals(value, result.get());
+		verify(redisUtil, times(1)).get(key, String.class);
+		verify(localCacheUtil, never()).get(any(), any());
+	}
+
+	@Test
+	void get_whenRedisDied_returnLocalCacheValue() {
+		//Given
+		String key = "testKey";
+		String value = "testValue";
+		doThrow(new RedisServerException()).when(redisUtil).get(key, String.class);
+		when(localCacheUtil.get(key, String.class)).thenReturn(Optional.of(value));
+
+		//When
+		Optional<String> result = hybridCacheUtil.get(key, String.class);
+
+		//Then
+		assertTrue(result.isPresent());
+		assertEquals(value, result.get());
+		verify(redisUtil, times(1)).get(key, String.class);
+		verify(localCacheUtil, times(1)).get(any(), any());
+	}
+
+	@Test
+	void set_whenRedisLive_callRedisUtilSet() {
+		//Given
+		String key = "testKey";
+		String value = "testValue";
+
+		//When
+		hybridCacheUtil.set(key, value, 1000L);
+
+		//Then
+		verify(redisUtil).set(key, value, 1000L);
+		verify(localCacheUtil, never()).set(any(), any(), anyLong());
+	}
+
+	@Test
+	void set_whenRedisDied_callLocalCacheUtilSet() {//Given
+		String key = "testKey";
+		String value = "testValue";
+		doThrow(new RedisServerException()).when(redisUtil).set(key, value, 1000L);
+
+		//When
+		hybridCacheUtil.set(key, value, 1000L);
+
+		//Then
+		verify(redisUtil, times(1)).set(key, value, 1000L);
+		verify(localCacheUtil, times(1)).set(key, value, 1000L);
+	}
+}

--- a/src/test/java/com/newzet/api/common/cache/LocalCacheUtilTest.java
+++ b/src/test/java/com/newzet/api/common/cache/LocalCacheUtilTest.java
@@ -1,0 +1,68 @@
+package com.newzet.api.common.cache;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.newzet.api.common.cache.local.LocalCacheUtil;
+
+public class LocalCacheUtilTest {
+
+	private LocalCacheUtil localCacheUtil;
+
+	@BeforeEach
+	void setUp() {
+		localCacheUtil = new LocalCacheUtil();
+	}
+
+	@Test
+	public void get_whenValueIsValid_returnOptionalValue() {
+		//Given
+		String key = "testKey";
+		String value = "testValue";
+		long ttl = 1000L;
+
+		localCacheUtil.set(key, value, ttl);
+		assertTrue(localCacheUtil.get(key, String.class).isPresent());
+
+		//When
+		Optional<String> cachedValue = localCacheUtil.get(key, String.class);
+
+		//Then
+		assertTrue(cachedValue.isPresent());
+		assertEquals(value, cachedValue.get());
+	}
+
+	@Test
+	public void get_whenValueNotExist_returnOptionalEmpty() {
+		//Given
+		String key = "testKey";
+
+		//When
+		Optional<String> cachedValue = localCacheUtil.get(key, String.class);
+
+		//Then
+		assertFalse(cachedValue.isPresent());
+	}
+
+	@Test
+	public void get_whenValueIsExpired_returnOptionalEmpty() throws InterruptedException {
+		//Given
+		String key = "testKey";
+		String value = "testValue";
+		long ttl = 1000L;
+
+		localCacheUtil.set(key, value, ttl);
+		assertTrue(localCacheUtil.get(key, String.class).isPresent());
+
+		//When
+		Thread.sleep(1100);
+		Optional<String> cachedValue = localCacheUtil.get(key, String.class);
+
+		//Then
+		assertFalse(localCacheUtil.get(key, String.class).isPresent());
+	}
+}

--- a/src/test/java/com/newzet/api/common/cache/RedisUtilTest.java
+++ b/src/test/java/com/newzet/api/common/cache/RedisUtilTest.java
@@ -34,28 +34,37 @@ class RedisUtilTest {
 	}
 
 	@Test
-	public void set_whenCachedValueNoExists_returnTrue() {
+	public void set_whenCachedValueNoExists() {
 		//Given
 		String key = "testKey";
 		String value = "testValue";
 		long ttl = 60000L;
 
-		//When, Then
-		assertTrue(redisUtil.set(key, value, ttl));
-	}
-
-	@Test
-	public void set_whenCachedValueExists_returnFalse() {
-		//Given
-		String key = "testKey";
-		String value = "testValue";
-		long ttl = 60000L;
+		assertFalse(redisUtil.get(key, String.class).isPresent());
 
 		//When
 		redisUtil.set(key, value, ttl);
 
+		//Then
+		assertTrue(redisUtil.get(key, String.class).isPresent());
+	}
+
+	@Test
+	public void set_whenCachedValueExists_updateTTL() throws InterruptedException {
+		//Given
+		String key = "testKey";
+		String value = "testValue";
+		long ttl = 1000L;
+
+		redisUtil.set(key, value, ttl);
+		assertTrue(redisUtil.get(key, String.class).isPresent());
+
+		//When
+		redisUtil.set(key, value, 3000L);
+
 		// Then
-		assertFalse(redisUtil.set(key, value, ttl));
+		Thread.sleep(1000L);
+		assertTrue(redisUtil.get(key, String.class).isPresent());
 	}
 
 	@Test

--- a/src/test/java/com/newzet/api/common/cache/RedisUtilTest.java
+++ b/src/test/java/com/newzet/api/common/cache/RedisUtilTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newzet.api.common.cache.redis.RedisUtil;
@@ -24,9 +25,12 @@ class RedisUtilTest {
 	@Autowired
 	private RedisUtil redisUtil;
 
+	@Autowired
+	private RedisTemplate<String, String> redisTemplate;
+
 	@AfterEach
 	void cleanUp() {
-		redisUtil.deleteAllKeys();
+		redisTemplate.delete(redisTemplate.keys("*"));
 	}
 
 	@Test
@@ -82,24 +86,5 @@ class RedisUtilTest {
 		//Then
 		assertTrue(returnValue.isPresent());
 		assertEquals(value, returnValue.get());
-	}
-
-	@Test
-	public void deleteAllKeys_whenKeysExist_deleteAllKeys() {
-		//Given
-		String key1 = "testKey1";
-		String key2 = "testKey2";
-		String value1 = "testValue1";
-		String value2 = "testValue2";
-		long ttl = 60000L;
-		redisUtil.set(key1, value1, ttl);
-		redisUtil.set(key2, value2, ttl);
-
-		//When
-		redisUtil.deleteAllKeys();
-
-		//Then
-		assertEquals(Optional.empty(), redisUtil.get(key1, String.class));
-		assertEquals(Optional.empty(), redisUtil.get(key2, String.class));
 	}
 }

--- a/src/test/java/com/newzet/api/common/cache/RedisUtilTest.java
+++ b/src/test/java/com/newzet/api/common/cache/RedisUtilTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
 import org.springframework.context.annotation.Import;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.newzet.api.common.cache.redis.RedisUtil;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.config.RedisTestContainerConfig;
 

--- a/src/test/java/com/newzet/api/common/lock/RedisLockFactoryTest.java
+++ b/src/test/java/com/newzet/api/common/lock/RedisLockFactoryTest.java
@@ -14,7 +14,7 @@ import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
 import org.springframework.context.annotation.Import;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.newzet.api.common.cache.RedisUtil;
+import com.newzet.api.common.cache.redis.RedisUtil;
 import com.newzet.api.common.lock.redis.RedisLock;
 import com.newzet.api.common.lock.redis.RedisLockFactory;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;

--- a/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceConcurrencyTest.java
+++ b/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceConcurrencyTest.java
@@ -40,11 +40,6 @@ public class NewsletterServiceConcurrencyTest {
 	private final String domain = "test@example.com";
 	private final String mailingList = "test123";
 
-	@BeforeEach
-	void setUp() {
-		cacheUtil.deleteAllKeys();
-	}
-
 	@Test
 	public void findOrCreateNewsletter_when100Requests_requestDB1time() throws
 		InterruptedException {

--- a/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
+++ b/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.newzet.api.common.cache.CacheUtil;
 import com.newzet.api.common.lock.LockFactory;
+import com.newzet.api.common.lock.exception.LockAcquisitionException;
 import com.newzet.api.newsletter.business.dto.NewsletterCacheDto;
 import com.newzet.api.newsletter.business.dto.NewsletterEntityDto;
 import com.newzet.api.newsletter.domain.Newsletter;
@@ -21,28 +22,23 @@ import com.newzet.api.newsletter.domain.Newsletter;
 @ExtendWith(MockitoExtension.class)
 class NewsletterServiceTest {
 
-	@Mock
-	private NewsletterRepository newsletterRepository;
-
-	@Mock
-	private CacheUtil cacheUtil;
-
-	@Mock
-	private LockFactory lockFactory;
-
-	@Mock
-	private Lock lock;
-
-	@InjectMocks
-	private NewsletterService newsletterService;
-
+	private static final String CACHE_DOMAIN_PREFIX = "newsletter:domain";
 	private final String name = "test";
 	private final String domain = "test@example.com";
 	private final String mailingList = "test123";
 	private final String status = "UNREGISTERED";
-	private static final String CACHE_DOMAIN_PREFIX = "newsletter:domain";
 	private final NewsletterEntityDto entityDto = NewsletterEntityDto.create(1L, name, domain,
 		mailingList, status);
+	@Mock
+	private NewsletterRepository newsletterRepository;
+	@Mock
+	private CacheUtil cacheUtil;
+	@Mock
+	private LockFactory lockFactory;
+	@Mock
+	private Lock lock;
+	@InjectMocks
+	private NewsletterService newsletterService;
 
 	@Test
 	void findOrCreateNewsletter_whenNewsletterExistsInCache_ReturnNewsletterInCache() {
@@ -113,16 +109,14 @@ class NewsletterServiceTest {
 		when(cacheUtil.get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class)).thenReturn(
 			Optional.empty());
 		when(lockFactory.tryLock(any(), anyLong(), anyLong())).thenReturn(Optional.empty());
-		when(newsletterRepository.findByDomainOrMailingList(domain, mailingList)).thenReturn(
-			Optional.of(entityDto));
 
 		// When
-		Newsletter newsletter = newsletterService.findOrCreateNewsletter(name, domain, mailingList);
+		assertThrows(LockAcquisitionException.class,
+			() -> newsletterService.findOrCreateNewsletter(name, domain, mailingList));
 
 		// Then
-		verifyValue(newsletter);
 		verify(cacheUtil, times(1)).get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class);
-		verify(newsletterRepository, times(1)).findByDomainOrMailingList(domain, mailingList);
+		verify(newsletterRepository, never()).findByDomainOrMailingList(domain, mailingList);
 		verify(cacheUtil, never()).set(eq(CACHE_DOMAIN_PREFIX + domain), any(), anyLong());
 		verify(lockFactory, never()).unlock(lock);
 	}


### PR DESCRIPTION
# 개요

- Redis 서버 다운 시 로컬 캐시로 전환을 위한 PR

# 배경

- Redis 서버 다운 시에는 모든 트래픽이 DB로 집중되어 DB Connection Pool이 다 차고 성능이 저하됨
- Redis 종료 시에도 DB의 부하를 최소화하기 위한 장치가 필요
- 성능이 빠르고 가벼운 Caffeine 로컬 캐시를 도입하면 서버 당 하나의 쿼리만 나가기 때문에 DB 부하를 줄일 수 있음
  - 로컬 캐시이기 때문에 분산환경에서 중복 쓰기가 발생할 수 있는데, 현재는 insert만 있기 때문에 unique 제약 조건으로 해결

# 변경된 점

- Caffeine Local Cache 도입
- Redis 서버 장애 시 Local Cache로 전환하는 HybridCacheUtil 추가
  - Redis 서버 장에 시 RedisServerException을 발생시키고, Local Cache로 전환하도록 설정
- Cache Util에 값을 저장하는 set 메서드의 반화 타입 void로 변경
- Cache Util에서 deleteAllKeys와 같이 운영에 위험한 메서드 제거
- DB DataIntegrityViolationException 발생 시 기존 데이터를 반환하도록 변경

## 참고자료
동작 흐름
![db-cache](https://github.com/user-attachments/assets/688d7685-7ec2-46b4-a28f-55586d9dab4e)
