### PR TITLE
Newsletter Service Refactoring

### DIFF
--- a/src/main/java/com/newzet/api/common/lock/HybridLockFactory.java
+++ b/src/main/java/com/newzet/api/common/lock/HybridLockFactory.java
@@ -1,7 +1,5 @@
 package com.newzet.api.common.lock;
 
-import java.util.Optional;
-import java.util.UnknownFormatConversionException;
 import java.util.concurrent.locks.Lock;
 
 import org.springframework.context.annotation.Primary;
@@ -26,10 +24,9 @@ public class HybridLockFactory implements LockFactory{
 	private final LocalLockFactory localLockFactory;
 
 	@Override
-	public Optional<Lock> tryLock(String lockKey, long waitTime, long leaseTime) {
+	public Lock tryLock(String lockKey, long waitTime, long leaseTime) {
 		try {
-			return redisLockFactory.tryLock(lockKey, waitTime, leaseTime)
-				.or(() -> localLockFactory.tryLock(lockKey, waitTime, leaseTime));
+			return redisLockFactory.tryLock(lockKey, waitTime, leaseTime);
 		} catch (RedisLockAcquisitionException e) {
 			return localLockFactory.tryLock(lockKey, waitTime, leaseTime);
 		}

--- a/src/main/java/com/newzet/api/common/lock/LockFactory.java
+++ b/src/main/java/com/newzet/api/common/lock/LockFactory.java
@@ -1,10 +1,9 @@
 package com.newzet.api.common.lock;
 
-import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 
 public interface LockFactory {
-	public Optional<Lock> tryLock(String lockKey, long waitTime, long leaseTime);
+	public Lock tryLock(String lockKey, long waitTime, long leaseTime);
 
 	public void unlock(Lock lock);
 }

--- a/src/main/java/com/newzet/api/common/lock/exception/LocalLockAcquisitionException.java
+++ b/src/main/java/com/newzet/api/common/lock/exception/LocalLockAcquisitionException.java
@@ -1,0 +1,7 @@
+package com.newzet.api.common.lock.exception;
+
+public class LocalLockAcquisitionException extends RuntimeException {
+	public LocalLockAcquisitionException() {
+		super();
+	}
+}

--- a/src/main/java/com/newzet/api/common/lock/exception/LockAcquisitionException.java
+++ b/src/main/java/com/newzet/api/common/lock/exception/LockAcquisitionException.java
@@ -1,7 +1,0 @@
-package com.newzet.api.common.lock.exception;
-
-public class LockAcquisitionException extends RuntimeException {
-	public LockAcquisitionException() {
-		super();
-	}
-}

--- a/src/main/java/com/newzet/api/common/lock/exception/RedisLockAcquisitionException.java
+++ b/src/main/java/com/newzet/api/common/lock/exception/RedisLockAcquisitionException.java
@@ -1,4 +1,7 @@
 package com.newzet.api.common.lock.exception;
 
-public class RedisLockAcquisitionException extends LockAcquisitionException {
+public class RedisLockAcquisitionException extends RuntimeException {
+	public RedisLockAcquisitionException() {
+		super();
+	}
 }

--- a/src/main/java/com/newzet/api/common/lock/local/LocalLockFactory.java
+++ b/src/main/java/com/newzet/api/common/lock/local/LocalLockFactory.java
@@ -1,6 +1,5 @@
 package com.newzet.api.common.lock.local;
 
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -9,6 +8,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.springframework.stereotype.Component;
 
 import com.newzet.api.common.lock.LockFactory;
+import com.newzet.api.common.lock.exception.LocalLockAcquisitionException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,14 +19,16 @@ public class LocalLockFactory implements LockFactory {
 	private final ConcurrentHashMap<String, Lock> locks = new ConcurrentHashMap<>();
 
 	@Override
-	public Optional<Lock> tryLock(String lockKey, long waitTime, long leaseTime) {
+	public Lock tryLock(String lockKey, long waitTime, long leaseTime) {
 		Lock lock = locks.computeIfAbsent(lockKey, k -> new ReentrantLock());
 		try {
-			boolean acquired = lock.tryLock(waitTime, TimeUnit.MILLISECONDS);
-			return acquired ? Optional.of(new LocalLock(lockKey, lock)) : Optional.empty();
+			if (!lock.tryLock(waitTime, TimeUnit.MILLISECONDS)) {
+				throw new LocalLockAcquisitionException();
+			}
+			return new LocalLock(lockKey, lock);
 		} catch (Exception e) {
 			log.error("[LocalLockFactory]: Redis lock 획득 실패, errorMessage: {}", e.getMessage());
-			return Optional.empty();
+			throw new LocalLockAcquisitionException();
 		}
 	}
 

--- a/src/main/java/com/newzet/api/common/lock/redis/RedisLockFactory.java
+++ b/src/main/java/com/newzet/api/common/lock/redis/RedisLockFactory.java
@@ -1,6 +1,5 @@
 package com.newzet.api.common.lock.redis;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
@@ -24,11 +23,13 @@ public class RedisLockFactory implements LockFactory {
 	private final RedissonClient redissonClient;
 
 	@Override
-	public Optional<Lock> tryLock(String lockKey, long waitTime, long leaseTime) {
+	public Lock tryLock(String lockKey, long waitTime, long leaseTime) {
 		RLock lock = redissonClient.getLock(LOCK_PREFIX + lockKey);
 		try {
-			boolean acquired = lock.tryLock(waitTime, leaseTime, TIME_UNIT);
-			return acquired ? Optional.of(new RedisLock(lock)) : Optional.empty();
+			if (!lock.tryLock(waitTime, leaseTime, TIME_UNIT)) {
+				throw new RedisLockAcquisitionException();
+			}
+			return new RedisLock(lock);
 		} catch (Exception e) {
 			log.error("[RedisLockFactory]: Redis lock 획득 실패, errorMessage: {}", e.getMessage());
 			throw new RedisLockAcquisitionException();

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.newzet.api.common.cache.CacheUtil;
 import com.newzet.api.common.lock.LockFactory;
-import com.newzet.api.common.lock.exception.LockAcquisitionException;
 import com.newzet.api.newsletter.business.dto.NewsletterCacheDto;
 import com.newzet.api.newsletter.business.dto.NewsletterEntityDto;
 import com.newzet.api.newsletter.domain.Newsletter;
@@ -45,15 +44,9 @@ public class NewsletterService {
 
 	private Newsletter findOrCreateByDomainOrMailingListWithLock(String name, String domain,
 		String mailingList) {
-		Optional<Lock> lockOptional = lockFactory.tryLock(CACHE_DOMAIN_PREFIX + ":" + domain,
+		Lock lock = lockFactory.tryLock(CACHE_DOMAIN_PREFIX + ":" + domain,
 			CACHE_LOCK_WAIT_TIME, CACHE_LOCK_LEASE_TIME);
 
-		if (lockOptional.isEmpty()) {
-			log.warn("[NewsletterService] lock 획득 실패, domain: {}", domain);
-			throw new LockAcquisitionException();
-		}
-
-		Lock lock = lockOptional.get();
 		try {
 			Optional<Newsletter> cachedNewsletter = findByDomainOnCache(domain);
 			if (cachedNewsletter.isPresent()) {

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
@@ -48,15 +48,8 @@ public class NewsletterService {
 			CACHE_LOCK_WAIT_TIME, CACHE_LOCK_LEASE_TIME);
 
 		try {
-			Optional<Newsletter> cachedNewsletter = findByDomainOnCache(domain);
-			if (cachedNewsletter.isPresent()) {
-				return cachedNewsletter.get();
-			}
-
-			Newsletter newsletter = findOrCreateByDomainOrMailingListInDatabase(name, domain,
-				mailingList);
-			cacheUtil.set(CACHE_DOMAIN_PREFIX + domain, newsletter.toCacheDto(), CACHE_DURATION);
-			return newsletter;
+			return findByDomainOnCache(domain).orElseGet(
+				() -> findOrCreateByDomainOrMailingListInDatabase(name, domain, mailingList));
 		} finally {
 			lockFactory.unlock(lock);
 		}
@@ -64,13 +57,20 @@ public class NewsletterService {
 
 	private Newsletter findOrCreateByDomainOrMailingListInDatabase(String name, String domain,
 		String mailingList) {
-		NewsletterEntityDto newsletterEntityDto = newsletterRepository
+		return newsletterRepository
 			.findByDomainOrMailingList(domain, mailingList)
-			.orElseGet(() -> newsletterRepository
-				.save(name, domain, mailingList, NewsletterStatus.UNREGISTERED.name()));
+			.map(NewsletterEntityDto::toDomain)
+			.map(newsletter -> {
+				cacheUtil.set(CACHE_DOMAIN_PREFIX + domain, newsletter.toCacheDto(), CACHE_DURATION);
+				return newsletter;
+			})
+			.orElseGet(() -> createNewsletter(name, domain, mailingList));
+	}
 
-		return Newsletter.create(newsletterEntityDto.getId(),
-			newsletterEntityDto.getName(), newsletterEntityDto.getDomain(),
-			newsletterEntityDto.getMailingList(), newsletterEntityDto.getStatus());
+	private Newsletter createNewsletter(String name, String domain, String mailingList) {
+		Newsletter savedNewsletter = newsletterRepository.save(name, domain, mailingList,
+			NewsletterStatus.UNREGISTERED.name()).toDomain();
+		cacheUtil.set(CACHE_DOMAIN_PREFIX + domain, savedNewsletter.toCacheDto(), CACHE_DURATION);
+		return savedNewsletter;
 	}
 }

--- a/src/test/java/com/newzet/api/common/lock/HybridLockFactoryTest.java
+++ b/src/test/java/com/newzet/api/common/lock/HybridLockFactoryTest.java
@@ -3,7 +3,6 @@ package com.newzet.api.common.lock;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -44,31 +43,14 @@ class HybridLockFactoryTest {
 		// Given
 		String key = "testLock";
 		when(redisLockFactory.tryLock(eq(key), anyLong(), anyLong()))
-			.thenReturn(Optional.of(redisLock));
+			.thenReturn(redisLock);
 
 		// When
-		Optional<Lock> lock = hybridLockFactory.tryLock(key, 500, 1000);
+		Lock lock = hybridLockFactory.tryLock(key, 500, 1000);
 
 		// Then
-		assertTrue(lock.isPresent());
-		assertEquals(redisLock, lock.get());
-	}
-	
-	@Test
-	public void tryLock_whenRedisLockFail_returnLocalLock() {
-		// Given
-		String key = "testLock";
-		when(redisLockFactory.tryLock(eq(key), anyLong(), anyLong()))
-			.thenReturn(Optional.empty());
-		when(localLockFactory.tryLock(eq(key), anyLong(), anyLong()))
-			.thenReturn(Optional.of(localLock));
-
-		// When
-		Optional<Lock> lock = hybridLockFactory.tryLock(key, 500, 1000);
-
-		// Then
-		assertTrue(lock.isPresent());
-		assertEquals(localLock, lock.get());
+		assertNotNull(lock);
+		assertEquals(redisLock, lock);
 	}
 	
 	@Test
@@ -78,14 +60,14 @@ class HybridLockFactoryTest {
 		when(redisLockFactory.tryLock(eq(key), anyLong(), anyLong()))
 			.thenThrow(new RedisLockAcquisitionException());
 		when(localLockFactory.tryLock(eq(key), anyLong(), anyLong()))
-			.thenReturn(Optional.of(localLock));
+			.thenReturn(localLock);
 
 		// When
-		Optional<Lock> lock = hybridLockFactory.tryLock(key, 500, 1000);
+		Lock lock = hybridLockFactory.tryLock(key, 500, 1000);
 
 		// Then
-		assertTrue(lock.isPresent());
-		assertEquals(localLock, lock.get());
+		assertNotNull(lock);
+		assertEquals(localLock, lock);
 	}
 
 	@Test

--- a/src/test/java/com/newzet/api/common/lock/LocalLockFactoryTest.java
+++ b/src/test/java/com/newzet/api/common/lock/LocalLockFactoryTest.java
@@ -2,13 +2,12 @@ package com.newzet.api.common.lock;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.newzet.api.common.lock.exception.LocalLockAcquisitionException;
 import com.newzet.api.common.lock.local.LocalLockFactory;
 
 public class LocalLockFactoryTest {
@@ -21,33 +20,37 @@ public class LocalLockFactoryTest {
 		String lockKey = "testLock";
 
 	    //When
-		Optional<Lock> lock = localLockFactory.tryLock(lockKey, 500, 2000);
+		Lock lock = localLockFactory.tryLock(lockKey, 500, 2000);
 
 	    //Then
-		assertTrue(lock.isPresent());
-		lock.get().unlock();
+		assertNotNull(lock);
+		lock.unlock();
 	}
 	
 	@Test
-	public void tryLock_whenLockAlreadyHeld_returnEmpty() throws InterruptedException{
+	public void tryLock_whenLockAlreadyHeld_throwLocalLockAcquisitionException() throws InterruptedException{
 		// Given
 		String lockKey = "testLock";
 
 		// When
-		Optional<Lock> firstLock = localLockFactory.tryLock(lockKey, 500, 5000);
-		assertTrue(firstLock.isPresent());
+		Lock firstLock = localLockFactory.tryLock(lockKey, 500, 5000);
+		assertNotNull(firstLock);
 
-		AtomicBoolean secondAcquired = new AtomicBoolean(true);
+		AtomicBoolean lockFailed = new AtomicBoolean(false);
 		Thread thread = new Thread(() -> {
-			Optional<Lock> secondLock = localLockFactory.tryLock(lockKey, 500, 5000);
-			secondAcquired.set(secondLock.isPresent());
+			try{
+				Lock secondLock = localLockFactory.tryLock(lockKey, 500, 5000);
+				secondLock.unlock();
+			} catch (LocalLockAcquisitionException e){
+				lockFailed.set(true);
+			}
 		});
 		thread.start();
 		thread.join();
 
 		// Then
-		assertFalse(secondAcquired.get());
-		firstLock.get().unlock();
+		assertTrue(lockFailed.get());
+		firstLock.unlock();
 	}
 
 	@Test
@@ -56,14 +59,14 @@ public class LocalLockFactoryTest {
 		String lockKey = "testLock";
 
 		// When
-		Optional<Lock> lock = localLockFactory.tryLock(lockKey, 500, 5000);
-		assertTrue(lock.isPresent());
-		lock.get().unlock();
+		Lock firstLock = localLockFactory.tryLock(lockKey, 500, 5000);
+		assertNotNull(firstLock);
+		firstLock.unlock();
 
 		// Then
-		Optional<Lock> reacquired = localLockFactory.tryLock(lockKey, 500, 1000);
-		assertTrue(reacquired.isPresent());
+		Lock secondLock = localLockFactory.tryLock(lockKey, 500, 1000);
+		assertNotNull(secondLock);
 
-		reacquired.get().unlock();
+		secondLock.unlock();
 	}
 }

--- a/src/test/java/com/newzet/api/common/lock/RedisLockFactoryTest.java
+++ b/src/test/java/com/newzet/api/common/lock/RedisLockFactoryTest.java
@@ -2,11 +2,9 @@ package com.newzet.api.common.lock;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +13,7 @@ import org.springframework.context.annotation.Import;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newzet.api.common.cache.redis.RedisUtil;
+import com.newzet.api.common.lock.exception.RedisLockAcquisitionException;
 import com.newzet.api.common.lock.redis.RedisLock;
 import com.newzet.api.common.lock.redis.RedisLockFactory;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
@@ -36,64 +35,71 @@ class RedisLockFactoryTest {
 		String lockKey = "testLock";
 
 		// When
-		Optional<Lock> lock = redisLockFactory.tryLock(lockKey, 500, 2000);
+		Lock lock = redisLockFactory.tryLock(lockKey, 500, 2000);
 
 		// Then
-		assertTrue(lock.isPresent());
-		Assertions.assertTrue(((RedisLock) lock.get()).isHeldByCurrentThread());
+		assertNotNull(lock);
+		assertTrue(((RedisLock) lock).isHeldByCurrentThread());
 
 		// Cleanup
-		lock.get().unlock();
+		lock.unlock();
 	}
 
 	@Test
-	void tryLock_whenLockAlreadyHeld_returnEmpty() throws InterruptedException {
+	void tryLock_whenLockAlreadyHeld_throwRedisLockAcquisitionException() throws InterruptedException {
 		// Given
 		String lockKey = "testLock";
-		Optional<Lock> firstLock = redisLockFactory.tryLock(lockKey, 500, 10000);
+		Lock firstLock = redisLockFactory.tryLock(lockKey, 500, 10000);
 
-		assertTrue(firstLock.isPresent());
-		assertTrue(((RedisLock)firstLock.get()).isHeldByCurrentThread());
+		assertNotNull(firstLock);
+		assertTrue(((RedisLock)firstLock).isHeldByCurrentThread());
 
 		// When
-		AtomicBoolean secondLockAcquired = new AtomicBoolean(true);
+		AtomicBoolean lockFailed = new AtomicBoolean(false);
 		Thread thread = new Thread(() -> {
-			Optional<Lock> secondLock = redisLockFactory.tryLock(lockKey, 500, 2000);
-			secondLockAcquired.set(secondLock.isPresent());
+			try {
+				Lock secondLock = redisLockFactory.tryLock(lockKey, 500, 2000);
+				secondLock.unlock();
+			} catch (RedisLockAcquisitionException e) {
+				lockFailed.set(true);
+			}
 		});
 
 		thread.start();
 		thread.join();
 
 		// Then
-		assertFalse(secondLockAcquired.get());
+		assertTrue(lockFailed.get());
 
 		// Cleanup
-		firstLock.get().unlock();
+		firstLock.unlock();
 	}
 
 	@Test
 	void unlock_whenUnlockOccurs() throws InterruptedException {
 		// Given
 		String lockKey = "testLock";
-		Optional<Lock> firstLock = redisLockFactory.tryLock(lockKey, 500, 10000);
+		Lock firstLock = redisLockFactory.tryLock(lockKey, 500, 10000);
 
-		assertTrue(firstLock.isPresent());
-		assertTrue(((RedisLock)firstLock.get()).isHeldByCurrentThread());
+		assertNotNull(firstLock);
+		assertTrue(((RedisLock)firstLock).isHeldByCurrentThread());
 
 		// When
-		AtomicBoolean secondLockAcquired = new AtomicBoolean(false);
+		AtomicBoolean lockFailed = new AtomicBoolean(false);
 		Thread thread = new Thread(() -> {
-			Optional<Lock> secondLock = redisLockFactory.tryLock(lockKey, 500, 2000);
-			secondLockAcquired.set(secondLock.isPresent());
-			secondLock.ifPresent(lock -> ((RedisLock)lock).unlock());
+			try{
+				Lock secondLock = redisLockFactory.tryLock(lockKey, 500, 2000);
+				((RedisLock) secondLock).unlock();
+			} catch	(Exception e) {
+				lockFailed.set(true);
+			}
 		});
 
-		firstLock.get().unlock();
+		firstLock.unlock();
 		thread.start();
 		thread.join();
 
 		// Then
-		assertTrue(secondLockAcquired.get());
+		assertFalse(lockFailed.get());
 	}
 }

--- a/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
+++ b/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.newzet.api.common.cache.CacheUtil;
 import com.newzet.api.common.lock.LockFactory;
-import com.newzet.api.common.lock.exception.LockAcquisitionException;
+import com.newzet.api.common.lock.exception.LocalLockAcquisitionException;
 import com.newzet.api.newsletter.business.dto.NewsletterCacheDto;
 import com.newzet.api.newsletter.business.dto.NewsletterEntityDto;
 import com.newzet.api.newsletter.domain.Newsletter;
@@ -63,7 +63,7 @@ class NewsletterServiceTest {
 		// Given
 		when(cacheUtil.get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class)).thenReturn(
 			Optional.empty());
-		when(lockFactory.tryLock(any(), anyLong(), anyLong())).thenReturn(Optional.of(lock));
+		when(lockFactory.tryLock(any(), anyLong(), anyLong())).thenReturn(lock);
 		when(newsletterRepository.findByDomainOrMailingList(domain, mailingList)).thenReturn(
 			Optional.of(entityDto));
 
@@ -85,7 +85,7 @@ class NewsletterServiceTest {
 		// Given
 		when(cacheUtil.get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class)).thenReturn(
 			Optional.empty());
-		when(lockFactory.tryLock(any(), anyLong(), anyLong())).thenReturn(Optional.of(lock));
+		when(lockFactory.tryLock(any(), anyLong(), anyLong())).thenReturn(lock);
 		when(newsletterRepository.findByDomainOrMailingList(domain, mailingList)).thenReturn(
 			Optional.empty());
 		when(newsletterRepository.save(any(), any(), any(), any())).thenReturn(entityDto);
@@ -108,10 +108,10 @@ class NewsletterServiceTest {
 		//Given
 		when(cacheUtil.get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class)).thenReturn(
 			Optional.empty());
-		when(lockFactory.tryLock(any(), anyLong(), anyLong())).thenReturn(Optional.empty());
+		when(lockFactory.tryLock(any(), anyLong(), anyLong())).thenThrow(new LocalLockAcquisitionException());
 
 		// When
-		assertThrows(LockAcquisitionException.class,
+		assertThrows(LocalLockAcquisitionException.class,
 			() -> newsletterService.findOrCreateNewsletter(name, domain, mailingList));
 
 		// Then


### PR DESCRIPTION
# 배경

- Newsletter Service 코드에서 Lock 생성 시 불필요한 Optional을 쓰고 있었음.
- Newsletter 생성과 조회가 한개의 메서드에 묶여 있었음.

# 변경된 점

- LockFactory의 tryLock() 메서드의 반환값을 Optional<Lock>에서 Lock으로 변경
  - 하위 클래스 및 테스트 코드 모두 수정 
- Newsletter Service의 메서드가 한개의 역할만 수행하도록 분리