### PR TITLE
Web및 Swagger Config 추가 및 웹 개발용 CORS open, Swagger JWT 헤더 자동 추가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // open api 추가
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
 }
 
 test {

--- a/src/main/java/com/newzet/api/config/SwaggerConfig.java
+++ b/src/main/java/com/newzet/api/config/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package com.newzet.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+	public static final String BEARER_AUTH = "BearerAuth";
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.components(new Components())
+			.info(createApiInfo())
+			.addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH))
+			.schemaRequirement(BEARER_AUTH, createSecurityScheme());
+	}
+
+	private Info createApiInfo() {
+		return new Info()
+			.title("뉴젯 API 명세서")
+			.description(
+				"[Team Notion 바로가기](https://www.notion.so/1c8b6c7804e2804081c3fd2647c58a47)")
+			.version("0.0.1");
+	}
+
+	public SecurityScheme createSecurityScheme() {
+		return new SecurityScheme()
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("JWT")
+			.in(SecurityScheme.In.HEADER)
+			.name("Authorization");
+	}
+}

--- a/src/main/java/com/newzet/api/config/WebConfig.java
+++ b/src/main/java/com/newzet/api/config/WebConfig.java
@@ -1,0 +1,26 @@
+package com.newzet.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Bean
+	public CorsFilter corsFilter() {
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowCredentials(true);
+		config.addAllowedOriginPattern("*");
+		config.addAllowedHeader("*");
+		config.addAllowedMethod("*");
+		config.addExposedHeader("Authorization");
+		config.setMaxAge(3600L);
+		source.registerCorsConfiguration("/**", config);
+		return new CorsFilter(source);
+	}
+}

--- a/src/main/java/com/newzet/api/mail/presentation/MailController.java
+++ b/src/main/java/com/newzet/api/mail/presentation/MailController.java
@@ -8,17 +8,21 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.newzet.api.mail.business.MailServiceFacade;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/functions/v1/mail")
+@Tag(name = "메일", description = "메일 관련 API")
 public class MailController {
 
 	private final MailServiceFacade mailServiceFacade;
 
 	@PostMapping
+	@Operation(summary = "메일 수신", description = "메일을 수신하며 전달받은 메타데이터를 기반으로 뉴스레터 및 구독 관련 로직을 처리한다.")
 	public ResponseEntity<Object> receive(@RequestBody @Valid MailMetadataDto metadata) {
 		mailServiceFacade.processMail(metadata.getFromName(), metadata.getFromDomain(),
 			metadata.getToDomain(), metadata.getMailingList(), metadata.getHtmlLink());


### PR DESCRIPTION
# 개요
Spring Boot 프로젝트에서 공통 설정을 관리하고 Swagger를 통해 API 문서를 자동화하기 위해 WebConfig 및 SwaggerConfig 설정

# 배경
웹 개발용 CORS open 등 Web관련 Bean 등록 Configuration 부재 및 API 자동 문서화 툴 부재로 인한 추가

# 변경된 점
- 웹 관련 Bean 등록용 Configuration 추가
- 웹 개발용 CORS open
- Swagger Config 추가
- 추후 JWT 로그인 용 Bearer 헤더 자동 삽입기능 추가
- 기존 존재하는 Controller에 Swagger 어노테이션 삽입

## 참고자료
![image](https://github.com/user-attachments/assets/d4955bbf-7b3b-4af2-a095-344485bd4837)

## 관련 이슈

close #34 
