### PR TITLE
리프레쉬 토큰 저장시간의 TTL이 끝난 이후 요청하는 오류 해결

### DIFF
--- a/src/main/java/com/newzet/api/auth/business/validator/JwtValidator.java
+++ b/src/main/java/com/newzet/api/auth/business/validator/JwtValidator.java
@@ -37,12 +37,14 @@ public class JwtValidator {
 		}
 
 		tokenRepository.getLastRefreshTime(userId, deviceType)
-			.ifPresent(lastRefreshTime -> {
-				if ((System.currentTimeMillis() - lastRefreshTime)
-					< REFRESH_RATE_LIMIT_MILLISECONDS) {
-					throw new TokenConflictException("1분 이내에 이미 재발급 요청이 있었습니다.");
-				}
-			});
+			.ifPresent(this::checkRefreshInterval);
+	}
+
+	private void checkRefreshInterval(long lastRefreshTime) {
+		long currentTime = System.currentTimeMillis();
+		if ((currentTime - lastRefreshTime) < REFRESH_RATE_LIMIT_MILLISECONDS) {
+			throw new TokenConflictException("1분 이내에 이미 재발급 요청이 있었습니다.");
+		}
 	}
 
 	public void validateAccessToken(Token token) {

--- a/src/main/java/com/newzet/api/auth/business/validator/JwtValidator.java
+++ b/src/main/java/com/newzet/api/auth/business/validator/JwtValidator.java
@@ -36,11 +36,13 @@ public class JwtValidator {
 			throw new TokenStolenException("리프레시 토큰이 일치하지 않습니다. 토큰 탈취 가능성.");
 		}
 
-		Long lastRefreshTime = tokenRepository.getLastRefreshTime(userId, deviceType);
-
-		if ((System.currentTimeMillis() - lastRefreshTime) < REFRESH_RATE_LIMIT_MILLISECONDS) {
-			throw new TokenConflictException("1분 이내에 이미 재발급 요청이 있었습니다.");
-		}
+		tokenRepository.getLastRefreshTime(userId, deviceType)
+			.ifPresent(lastRefreshTime -> {
+				if ((System.currentTimeMillis() - lastRefreshTime)
+					< REFRESH_RATE_LIMIT_MILLISECONDS) {
+					throw new TokenConflictException("1분 이내에 이미 재발급 요청이 있었습니다.");
+				}
+			});
 	}
 
 	public void validateAccessToken(Token token) {

--- a/src/main/java/com/newzet/api/auth/infrastructure/RedisRefreshTokenRepository.java
+++ b/src/main/java/com/newzet/api/auth/infrastructure/RedisRefreshTokenRepository.java
@@ -45,10 +45,10 @@ public class RedisRefreshTokenRepository implements TokenRepository {
 	}
 
 	@Override
-	public Long getLastRefreshTime(String userId, String deviceType) {
+	public Optional<Long> getLastRefreshTime(String userId, String deviceType) {
 		String timeKey = generateTimeKey(userId, deviceType);
 		String value = redisTemplate.opsForValue().get(timeKey);
-		return value != null ? Long.valueOf(value) : null;
+		return Optional.ofNullable(value).map(Long::valueOf);
 	}
 
 	@Override

--- a/src/main/java/com/newzet/api/auth/infrastructure/TokenRepository.java
+++ b/src/main/java/com/newzet/api/auth/infrastructure/TokenRepository.java
@@ -11,7 +11,7 @@ public interface TokenRepository {
 
 	void removeToken(String userId, String deviceType);
 
-	Long getLastRefreshTime(String userId, String deviceType);
+	Optional<Long> getLastRefreshTime(String userId, String deviceType);
 
 	void updateLastRefreshTime(String userId, String deviceType);
 }

--- a/src/test/java/com/newzet/api/auth/business/validator/JwtValidatorTest.java
+++ b/src/test/java/com/newzet/api/auth/business/validator/JwtValidatorTest.java
@@ -78,7 +78,7 @@ class JwtValidatorTest {
 		Token token = Token.of(TokenType.REFRESH, tokenValue, userId, new Date(), future);
 
 		when(tokenRepository.findToken(userId, deviceType)).thenReturn(Optional.of(token));
-		when(tokenRepository.getLastRefreshTime(userId, deviceType)).thenReturn(0L);
+		when(tokenRepository.getLastRefreshTime(userId, deviceType)).thenReturn(Optional.of(0L));
 
 		//When, Then
 		assertThatCode(() -> JWTValidator.validateRefreshToken(token, userId, deviceType))
@@ -133,7 +133,8 @@ class JwtValidatorTest {
 		long recentTime = System.currentTimeMillis() - 30 * 1000;
 
 		when(tokenRepository.findToken(userId, deviceType)).thenReturn(Optional.of(token));
-		when(tokenRepository.getLastRefreshTime(userId, deviceType)).thenReturn(recentTime);
+		when(tokenRepository.getLastRefreshTime(userId, deviceType)).thenReturn(
+			Optional.of(recentTime));
 
 		//When, Then
 		assertThatThrownBy(() -> JWTValidator.validateRefreshToken(token, userId, deviceType))

--- a/src/test/java/com/newzet/api/auth/infrastructure/RedisRefreshTokenRepositoryIntegrationTest.java
+++ b/src/test/java/com/newzet/api/auth/infrastructure/RedisRefreshTokenRepositoryIntegrationTest.java
@@ -96,22 +96,23 @@ class RedisRefreshTokenRepositoryIntegrationTest {
 		// When
 		tokenRepository.updateLastRefreshTime(userId, deviceType);
 		long afterUpdate = System.currentTimeMillis();
-		long lastRefreshTime = tokenRepository.getLastRefreshTime(userId, deviceType);
+		Optional<Long> lastRefreshTime = tokenRepository.getLastRefreshTime(userId, deviceType);
 
 		// Then
-		assertThat(lastRefreshTime).isBetween(beforeUpdate, afterUpdate);
+		assertThat(lastRefreshTime).isPresent();
+		assertThat(lastRefreshTime.get()).isBetween(beforeUpdate, afterUpdate);
 	}
 
 	@Test
-	public void getLastRefreshTime_whenTimeNotSet_thenReturnsNull() {
+	public void getLastRefreshTime_whenTimeNotSet_thenReturnsEmpty() {
 		// Given
 		String newUserId = "another-user";
 
 		// When
-		Long lastRefreshTime = tokenRepository.getLastRefreshTime(newUserId, deviceType);
+		Optional<Long> lastRefreshTime = tokenRepository.getLastRefreshTime(newUserId, deviceType);
 
 		// Then
-		assertThat(lastRefreshTime).isNull();
+		assertThat(lastRefreshTime).isEmpty();
 	}
 
 	@Test

--- a/src/test/java/com/newzet/api/auth/infrastructure/RedisRefreshTokenRepositoryTest.java
+++ b/src/test/java/com/newzet/api/auth/infrastructure/RedisRefreshTokenRepositoryTest.java
@@ -110,10 +110,11 @@ class RedisRefreshTokenRepositoryTest {
 		when(valueOperations.get(timeKey)).thenReturn(String.valueOf(timestamp));
 
 		// When
-		Long result = tokenRepository.getLastRefreshTime(userId, deviceType);
+		Optional<Long> result = tokenRepository.getLastRefreshTime(userId, deviceType);
 
 		// Then
-		assertThat(result).isEqualTo(timestamp);
+		assertThat(result).isPresent();
+		assertThat(result.get()).isEqualTo(timestamp);
 	}
 
 	@Test
@@ -126,5 +127,18 @@ class RedisRefreshTokenRepositoryTest {
 
 		//Then
 		verify(valueOperations).set(eq(timeKey), anyString(), anyLong(), eq(TimeUnit.MILLISECONDS));
+	}
+
+	@Test
+	void getLastRefreshTime_shouldReturnEmptyOptional_whenTimeDoesNotExist() {
+		// given
+		String timeKey = "refresh-time:" + userId + ":" + deviceType;
+		when(redisTemplate.opsForValue().get(timeKey)).thenReturn(null);
+
+		// when
+		Optional<Long> result = tokenRepository.getLastRefreshTime(userId, deviceType);
+
+		// then
+		assertThat(result).isEmpty();
 	}
 }


### PR DESCRIPTION
# 개요
리프레시 토큰의 마지막 저장 시간에 대한 TTL 만료 후 null 반환 시 발생하는 NullPointerException을 해결

# 배경
현재 시스템에서는 유저와 디바이스별로 리프레시 토큰의 최근 갱신 시간을 Redis에 저장하고 있으며, 이 값의 TTL은 현재 REFRESH_TOKEN_VALIDITY_MILLISECONDS에 맞추어 1분으로 설정되어 있습니다. 
하지만 TTL이 만료된 후 해당 값을 조회할 때 null을 적절히 처리하지 못해 NullPointerException이 발생하는 문제를 확인했습니다.

# 변경된 점
- 인터페이스의 메서드의 반환 타입을 Optional<Long> 으로 수정
- 구현체에서 getLastRefreshTime 메서드가 Redis에서 null을 반환받을 경우 빈 Optional을 반환하도록 수정
- JwtValidator의 validateRefreshToken 메서드에서 getLastRefreshTime의 결과를 Optional로 처리하도록 수정
- 관련 테스트코드 타입 수정 및 추가

## 참고자료