### PR TITLE
Refactor: UserEntity단에 toEntityDto 도입

### DIFF
--- a/src/main/java/com/newzet/api/user/repository/entity/UserEntity.java
+++ b/src/main/java/com/newzet/api/user/repository/entity/UserEntity.java
@@ -60,4 +60,8 @@ public class UserEntity {
 		this.nickName = userEntityDto.getNickname();
 		this.status = UserEntityStatus.valueOf(userEntityDto.getStatus());
 	}
+
+	public UserEntityDto toEntityDto() {
+		return UserEntityDto.create(id, email, nickName, status.name());
+	}
 }

--- a/src/main/java/com/newzet/api/user/repository/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/newzet/api/user/repository/repository/UserRepositoryImpl.java
@@ -22,8 +22,7 @@ public class UserRepositoryImpl implements UserRepository {
 	public UserEntityDto save(String email, String nickName, String status) {
 		UserEntity user = UserEntity.create(email, nickName, status);
 		UserEntity savedUser = userJpaRepository.save(user);
-		return UserEntityDto.create(savedUser.getId(), savedUser.getEmail(),
-			savedUser.getNickName(), savedUser.getStatus().name());
+		return savedUser.toEntityDto();
 	}
 
 	@Override
@@ -46,19 +45,13 @@ public class UserRepositoryImpl implements UserRepository {
 		UserEntity user = userJpaRepository.findByEmail(email)
 			.orElseThrow(() -> new NoUserException("사용자를 찾을 수 없습니다."));
 
-		return UserEntityDto.create(user.getId(), user.getEmail(), user.getNickName(),
-			user.getStatus().name());
+		return user.toEntityDto();
 	}
 
 	@Override
 	public Optional<UserEntityDto> findOptionalByEmail(String email) {
 		return userJpaRepository.findByEmail(email)
-			.map(userEntity -> UserEntityDto.create(
-				userEntity.getId(),
-				userEntity.getEmail(),
-				userEntity.getNickName(),
-				userEntity.getStatus().name()
-			));
+			.map(UserEntity::toEntityDto);
 	}
 
 	@Override
@@ -66,7 +59,6 @@ public class UserRepositoryImpl implements UserRepository {
 		UserEntity user = userJpaRepository.findById(userId)
 			.orElseThrow(() -> new NoUserException("사용자를 찾을 수 없습니다."));
 
-		return UserEntityDto.create(user.getId(), user.getEmail(), user.getNickName(),
-			user.getStatus().name());
+		return user.toEntityDto();
 	}
 }


### PR DESCRIPTION
# 개요
- UserEntity단에 toEntityDto 도입

# 배경
- 현재 toEntityDto없이 create를 직접 사용하여 코드 길이가 길어지는 문제가 존재

# 변경된 점
- UserEntity단에 toEntityDto 도입
- 관련 로직 적용

## 참고자료
x

## 관련 이슈

close #57 
