### PR TITLE
Token 도메인과 repository단의 종속성 제거

### DIFF
--- a/src/main/java/com/newzet/api/auth/business/dto/TokenDTO.java
+++ b/src/main/java/com/newzet/api/auth/business/dto/TokenDTO.java
@@ -1,0 +1,13 @@
+package com.newzet.api.auth.business.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record TokenDTO(
+	String value
+) {
+	public static TokenDTO of(String value) {
+		return TokenDTO.builder().value(value).build();
+	}
+}

--- a/src/main/java/com/newzet/api/auth/business/dto/TokenDTO.java
+++ b/src/main/java/com/newzet/api/auth/business/dto/TokenDTO.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 public record TokenDTO(
 	String value
 ) {
-	public static TokenDTO of(String value) {
+	public static TokenDTO from(String value) {
 		return TokenDTO.builder().value(value).build();
 	}
 }

--- a/src/main/java/com/newzet/api/auth/business/service/JwtService.java
+++ b/src/main/java/com/newzet/api/auth/business/service/JwtService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.newzet.api.auth.business.dto.JwtRefreshRequest;
 import com.newzet.api.auth.business.dto.JwtResponse;
+import com.newzet.api.auth.business.dto.TokenDTO;
 import com.newzet.api.auth.business.validator.JwtValidator;
 import com.newzet.api.auth.domain.Token;
 import com.newzet.api.auth.exception.TokenBadRequestException;
@@ -33,7 +34,9 @@ public class JwtService {
 		Token newAccessToken = jwtFactory.createAccessToken(userId);
 		Token newRefreshToken = jwtFactory.createRefreshToken(userId);
 
-		tokenRepository.saveToken(userId, deviceType, newRefreshToken);
+		TokenDTO newRefreshTokenDTO = newRefreshToken.toTokenDTO();
+
+		tokenRepository.saveToken(userId, deviceType, newRefreshTokenDTO);
 		tokenRepository.updateLastRefreshTime(userId, deviceType);
 
 		return new JwtResponse(newAccessToken.getValue(), newRefreshToken.getValue());

--- a/src/main/java/com/newzet/api/auth/business/service/TokenRepository.java
+++ b/src/main/java/com/newzet/api/auth/business/service/TokenRepository.java
@@ -3,12 +3,12 @@ package com.newzet.api.auth.business.service;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.newzet.api.auth.domain.Token;
+import com.newzet.api.auth.business.dto.TokenDTO;
 
 public interface TokenRepository {
-	void saveToken(UUID userId, String deviceType, Token token);
+	void saveToken(UUID userId, String deviceType, TokenDTO tokenDTO);
 
-	Optional<Token> findToken(UUID userId, String deviceType);
+	TokenDTO findToken(UUID userId, String deviceType);
 
 	void removeToken(UUID userId, String deviceType);
 

--- a/src/main/java/com/newzet/api/auth/business/validator/JwtValidator.java
+++ b/src/main/java/com/newzet/api/auth/business/validator/JwtValidator.java
@@ -34,8 +34,12 @@ public class JwtValidator {
 
 		TokenDTO storedTokenDTO = tokenRepository.findToken(userId, deviceType);
 
+		if (storedTokenDTO.value() == null) {
+			throw new TokenBadRequestException("저장된 리프레시 토큰이 없습니다. 재로그인이 필요합니다.");
+		}
+
 		Token storedToken = jwtFactory.parseToken(storedTokenDTO.value())
-			.orElseThrow(() -> new TokenBadRequestException("저장된 리프레시 토큰이 없습니다. 재로그인이 필요합니다."));
+			.orElseThrow(() -> new TokenBadRequestException("유효하지 않은 토큰입니다."));
 
 		if (!storedToken.isSameValue(token.getValue())) {
 			tokenRepository.removeToken(userId, deviceType);

--- a/src/main/java/com/newzet/api/auth/business/validator/JwtValidator.java
+++ b/src/main/java/com/newzet/api/auth/business/validator/JwtValidator.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
+import com.newzet.api.auth.business.dto.TokenDTO;
+import com.newzet.api.auth.business.service.JwtFactory;
 import com.newzet.api.auth.business.service.TokenRepository;
 import com.newzet.api.auth.domain.Token;
 import com.newzet.api.auth.exception.TokenBadRequestException;
@@ -19,6 +21,7 @@ public class JwtValidator {
 	private static final long REFRESH_RATE_LIMIT_MILLISECONDS = 60 * 1000;
 
 	private final TokenRepository tokenRepository;
+	private final JwtFactory jwtFactory;
 
 	public void validateRefreshToken(Token token, UUID userId, String deviceType) {
 		if (!token.isRefreshToken()) {
@@ -29,11 +32,12 @@ public class JwtValidator {
 			throw new TokenExpiredException("리프레시 토큰이 만료되었습니다.");
 		}
 
-		String storedTokenValue = tokenRepository.findToken(userId, deviceType)
-			.map(Token::getValue)
+		TokenDTO storedTokenDTO = tokenRepository.findToken(userId, deviceType);
+
+		Token storedToken = jwtFactory.parseToken(storedTokenDTO.value())
 			.orElseThrow(() -> new TokenBadRequestException("저장된 리프레시 토큰이 없습니다. 재로그인이 필요합니다."));
 
-		if (!storedTokenValue.equals(token.getValue())) {
+		if (!storedToken.isSameValue(token.getValue())) {
 			tokenRepository.removeToken(userId, deviceType);
 			throw new TokenStolenException("리프레시 토큰이 일치하지 않습니다. 토큰 탈취 가능성.");
 		}

--- a/src/main/java/com/newzet/api/auth/domain/Token.java
+++ b/src/main/java/com/newzet/api/auth/domain/Token.java
@@ -39,6 +39,6 @@ public class Token {
 	}
 
 	public TokenDTO toTokenDTO() {
-		return TokenDTO.of(this.value);
+		return TokenDTO.from(this.value);
 	}
 }

--- a/src/main/java/com/newzet/api/auth/domain/Token.java
+++ b/src/main/java/com/newzet/api/auth/domain/Token.java
@@ -2,6 +2,8 @@ package com.newzet.api.auth.domain;
 
 import java.util.Date;
 
+import com.newzet.api.auth.business.dto.TokenDTO;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,5 +32,13 @@ public class Token {
 
 	public boolean isRefreshToken() {
 		return this.type.equals(TokenType.REFRESH);
+	}
+
+	public boolean isSameValue(String value) {
+		return this.value.equals(value);
+	}
+
+	public TokenDTO toTokenDTO() {
+		return TokenDTO.of(this.value);
 	}
 }

--- a/src/main/java/com/newzet/api/auth/repository/RedisTokenRepositoryImpl.java
+++ b/src/main/java/com/newzet/api/auth/repository/RedisTokenRepositoryImpl.java
@@ -35,7 +35,7 @@ public class RedisTokenRepositoryImpl implements TokenRepository {
 	public TokenDTO findToken(UUID userId, String deviceType) {
 		String key = generateKey(userId, deviceType);
 		String tokenValue = redisTemplate.opsForValue().get(key);
-		return TokenDTO.of(tokenValue);
+		return TokenDTO.from(tokenValue);
 	}
 
 	@Override

--- a/src/main/java/com/newzet/api/auth/repository/RedisTokenRepositoryImpl.java
+++ b/src/main/java/com/newzet/api/auth/repository/RedisTokenRepositoryImpl.java
@@ -9,9 +9,8 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import com.newzet.api.auth.business.service.JwtFactory;
+import com.newzet.api.auth.business.dto.TokenDTO;
 import com.newzet.api.auth.business.service.TokenRepository;
-import com.newzet.api.auth.domain.Token;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,21 +22,20 @@ public class RedisTokenRepositoryImpl implements TokenRepository {
 	private static final long REFRESH_REQUEST_INTERVAL_LIMIT = 60 * 1000L;
 
 	private final RedisTemplate<String, String> redisTemplate;
-	private final JwtFactory jwtFactory;
 
 	@Override
-	public void saveToken(UUID userId, String deviceType, Token token) {
+	public void saveToken(UUID userId, String deviceType, TokenDTO tokenDTO) {
 		String key = generateKey(userId, deviceType);
 		redisTemplate.opsForValue()
-			.set(key, token.getValue(), REFRESH_TOKEN_VALIDITY_MILLISECONDS, TimeUnit.MILLISECONDS);
+			.set(key, tokenDTO.value(), REFRESH_TOKEN_VALIDITY_MILLISECONDS, TimeUnit.MILLISECONDS);
 		updateLastRefreshTime(userId, deviceType);
 	}
 
 	@Override
-	public Optional<Token> findToken(UUID userId, String deviceType) {
+	public TokenDTO findToken(UUID userId, String deviceType) {
 		String key = generateKey(userId, deviceType);
 		String tokenValue = redisTemplate.opsForValue().get(key);
-		return jwtFactory.parseToken(tokenValue);
+		return TokenDTO.of(tokenValue);
 	}
 
 	@Override

--- a/src/test/java/com/newzet/api/auth/business/service/JwtServiceTest.java
+++ b/src/test/java/com/newzet/api/auth/business/service/JwtServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.newzet.api.auth.business.dto.JwtRefreshRequest;
 import com.newzet.api.auth.business.dto.JwtResponse;
+import com.newzet.api.auth.business.dto.TokenDTO;
 import com.newzet.api.auth.business.validator.JwtValidator;
 import com.newzet.api.auth.domain.Token;
 import com.newzet.api.auth.domain.TokenType;
@@ -60,6 +61,7 @@ class JwtServiceTest {
 		Token newRefreshToken = Token.of(TokenType.REFRESH, "new-refresh-token", userId.toString(),
 			new Date(),
 			future);
+		TokenDTO newRefreshTokenDTO = newRefreshToken.toTokenDTO();
 
 		when(jwtFactory.parseToken(refreshTokenValue)).thenReturn(Optional.of(refreshToken));
 		when(jwtFactory.createAccessToken(userId)).thenReturn(newAccessToken);
@@ -72,7 +74,7 @@ class JwtServiceTest {
 		//Then
 		assertThat(response.accessToken()).isEqualTo(newAccessToken.getValue());
 		assertThat(response.refreshToken()).isEqualTo(newRefreshToken.getValue());
-		verify(tokenRepository).saveToken(userId, deviceType, newRefreshToken);
+		verify(tokenRepository).saveToken(userId, deviceType, newRefreshTokenDTO);
 		verify(tokenRepository).updateLastRefreshTime(userId, deviceType);
 	}
 

--- a/src/test/java/com/newzet/api/auth/business/validator/JwtValidatorTest.java
+++ b/src/test/java/com/newzet/api/auth/business/validator/JwtValidatorTest.java
@@ -106,6 +106,23 @@ class JwtValidatorTest {
 	}
 
 	@Test
+	public void validateRefreshToken_givenNullStoredTokenValue_throwsTokenBadRequestException() {
+		//Given
+		Date future = new Date(System.currentTimeMillis() + 1000 * 60);
+		Token nullValueToken = Token.of(TokenType.REFRESH, null, userId.toString(), new Date(),
+			future);
+		TokenDTO nullValueTokenDTO = nullValueToken.toTokenDTO();
+
+		//When
+		when(tokenRepository.findToken(userId, deviceType)).thenReturn(nullValueTokenDTO);
+
+		//Then
+		assertThatThrownBy(
+			() -> JWTValidator.validateRefreshToken(nullValueToken, userId, deviceType))
+			.isInstanceOf(TokenBadRequestException.class);
+	}
+
+	@Test
 	public void validateRefreshToken_whenExpiredToken_throwAccessTokenExpiredException() {
 		//Given
 		Date past = new Date(System.currentTimeMillis() - 1000 * 60);

--- a/src/test/java/com/newzet/api/auth/business/validator/JwtValidatorTest.java
+++ b/src/test/java/com/newzet/api/auth/business/validator/JwtValidatorTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.newzet.api.auth.business.dto.TokenDTO;
+import com.newzet.api.auth.business.service.JwtFactory;
 import com.newzet.api.auth.business.service.TokenRepository;
 import com.newzet.api.auth.domain.Token;
 import com.newzet.api.auth.domain.TokenType;
@@ -27,13 +29,16 @@ class JwtValidatorTest {
 	@Mock
 	private TokenRepository tokenRepository;
 
+	@Mock
+	private JwtFactory jwtFactory;
+
 	private JwtValidator JWTValidator;
 	private UUID userId;
 	private String deviceType;
 
 	@BeforeEach
 	void setUp() {
-		JWTValidator = new JwtValidator(tokenRepository);
+		JWTValidator = new JwtValidator(tokenRepository, jwtFactory);
 		userId = UUID.randomUUID();
 		deviceType = "web";
 	}
@@ -78,8 +83,10 @@ class JwtValidatorTest {
 		String tokenValue = "refresh-token-value";
 		Token token = Token.of(TokenType.REFRESH, tokenValue, userId.toString(), new Date(),
 			future);
+		TokenDTO tokenDTO = token.toTokenDTO();
 
-		when(tokenRepository.findToken(userId, deviceType)).thenReturn(Optional.of(token));
+		when(tokenRepository.findToken(userId, deviceType)).thenReturn(tokenDTO);
+		when(jwtFactory.parseToken(tokenDTO.value())).thenReturn(Optional.of(token));
 		when(tokenRepository.getLastRefreshTime(userId, deviceType)).thenReturn(Optional.of(0L));
 
 		//When, Then
@@ -118,8 +125,10 @@ class JwtValidatorTest {
 		Token requestToken = Token.of(TokenType.REFRESH, "different-value", userId.toString(),
 			new Date(),
 			future);
+		TokenDTO storedTokenDTO = requestToken.toTokenDTO();
 
-		when(tokenRepository.findToken(userId, deviceType)).thenReturn(Optional.of(storedToken));
+		when(tokenRepository.findToken(userId, deviceType)).thenReturn(storedTokenDTO);
+		when(jwtFactory.parseToken(storedTokenDTO.value())).thenReturn(Optional.of(storedToken));
 
 		//When, Then
 		assertThatThrownBy(
@@ -135,9 +144,12 @@ class JwtValidatorTest {
 		String tokenValue = "refresh-token-value";
 		Token token = Token.of(TokenType.REFRESH, tokenValue, userId.toString(), new Date(),
 			future);
+		TokenDTO tokenDTO = token.toTokenDTO();
+
 		long recentTime = System.currentTimeMillis() - 30 * 1000;
 
-		when(tokenRepository.findToken(userId, deviceType)).thenReturn(Optional.of(token));
+		when(tokenRepository.findToken(userId, deviceType)).thenReturn(tokenDTO);
+		when(jwtFactory.parseToken(tokenDTO.value())).thenReturn(Optional.of(token));
 		when(tokenRepository.getLastRefreshTime(userId, deviceType)).thenReturn(
 			Optional.of(recentTime));
 

--- a/src/test/java/com/newzet/api/auth/repository/RedisTokenRepositoryImplIntegrationTest.java
+++ b/src/test/java/com/newzet/api/auth/repository/RedisTokenRepositoryImplIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.redis.core.RedisTemplate;
 
+import com.newzet.api.auth.business.dto.TokenDTO;
 import com.newzet.api.auth.business.service.JwtFactory;
 import com.newzet.api.auth.domain.Token;
 import com.newzet.api.config.JwtTestConfig;
@@ -38,6 +39,7 @@ class RedisTokenRepositoryImplIntegrationTest {
 	private UUID userId;
 	private String deviceType;
 	private Token refreshToken;
+	private TokenDTO refreshTokenDTO;
 
 	@BeforeEach
 	void setUp() {
@@ -47,15 +49,17 @@ class RedisTokenRepositoryImplIntegrationTest {
 		deviceType = "mobile";
 
 		refreshToken = jwtFactory.createRefreshToken(userId);
+		refreshTokenDTO = refreshToken.toTokenDTO();
 	}
 
 	@Test
 	public void saveToken_whenValidInputs_thenTokenIsStored() {
 		// When
-		tokenRepository.saveToken(userId, deviceType, refreshToken);
+		tokenRepository.saveToken(userId, deviceType, refreshTokenDTO);
 
 		// Then
-		Optional<Token> foundToken = tokenRepository.findToken(userId, deviceType);
+		TokenDTO foundTokenDTO = tokenRepository.findToken(userId, deviceType);
+		Optional<Token> foundToken = jwtFactory.parseToken(foundTokenDTO.value());
 
 		assertThat(foundToken).isPresent();
 		assertThat(foundToken.get().getValue()).isEqualTo(refreshToken.getValue());
@@ -64,34 +68,35 @@ class RedisTokenRepositoryImplIntegrationTest {
 	}
 
 	@Test
-	public void findToken_whenTokenDoesNotExist_thenReturnsEmpty() {
+	public void findToken_whenTokenDoesNotExist_thenReturnsNullTokenValue() {
 		// Given
 		UUID nonExistingUserId = UUID.randomUUID();
 
 		// When
-		Optional<Token> result = tokenRepository.findToken(nonExistingUserId, deviceType);
+		TokenDTO result = tokenRepository.findToken(nonExistingUserId, deviceType);
 
 		// Then
-		assertThat(result).isEmpty();
+		assertThat(result.value()).isNull();
 	}
 
 	@Test
 	public void removeToken_whenTokenExists_thenTokenIsRemoved() {
 		// Given
-		tokenRepository.saveToken(userId, deviceType, refreshToken);
+		tokenRepository.saveToken(userId, deviceType, refreshTokenDTO);
+		UUID nonExistingUserId = UUID.randomUUID();
 
 		// When
 		tokenRepository.removeToken(userId, deviceType);
 
 		// Then
-		Optional<Token> result = tokenRepository.findToken(userId, deviceType);
-		assertThat(result).isEmpty();
+		TokenDTO result = tokenRepository.findToken(nonExistingUserId, deviceType);
+		assertThat(result.value()).isNull();
 	}
 
 	@Test
 	public void getLastRefreshTime_whenTimeIsSet_thenReturnsCorrectTime() {
 		// Given
-		tokenRepository.saveToken(userId, deviceType, refreshToken);
+		tokenRepository.saveToken(userId, deviceType, refreshTokenDTO);
 		long beforeUpdate = System.currentTimeMillis();
 
 		// When
@@ -119,21 +124,22 @@ class RedisTokenRepositoryImplIntegrationTest {
 	@Test
 	public void saveToken_whenCalledMultipleTimesForSameUser_thenOverwritesPreviousToken() {
 		// Given
-		tokenRepository.saveToken(userId, deviceType, refreshToken);
+		tokenRepository.saveToken(userId, deviceType, refreshTokenDTO);
 
 		sleep(1000);
 
 		Token newRefreshToken = jwtFactory.createRefreshToken(userId);
+		TokenDTO newRefreshTokenDTO = newRefreshToken.toTokenDTO();
 
 		// When
-		tokenRepository.saveToken(userId, deviceType, newRefreshToken);
+		tokenRepository.saveToken(userId, deviceType, newRefreshTokenDTO);
 
 		// Then
-		Optional<Token> foundToken = tokenRepository.findToken(userId, deviceType);
+		TokenDTO foundTokenDTO = tokenRepository.findToken(userId, deviceType);
 
-		assertThat(foundToken).isPresent();
-		assertThat(foundToken.get().getValue()).isEqualTo(newRefreshToken.getValue());
-		assertThat(foundToken.get().getValue()).isNotEqualTo(refreshToken.getValue());
+		assertThat(foundTokenDTO).isNotNull();
+		assertThat(foundTokenDTO.value()).isEqualTo(newRefreshToken.getValue());
+		assertThat(foundTokenDTO.value()).isNotEqualTo(refreshToken.getValue());
 	}
 
 	@Test
@@ -141,23 +147,24 @@ class RedisTokenRepositoryImplIntegrationTest {
 		// Given
 		String otherDeviceType = "desktop";
 		Token otherDeviceToken = jwtFactory.createRefreshToken(userId);
+		TokenDTO otherDeviceTokenDTO = otherDeviceToken.toTokenDTO();
 
 		// When
-		tokenRepository.saveToken(userId, deviceType, refreshToken);
-		tokenRepository.saveToken(userId, otherDeviceType, otherDeviceToken);
+		tokenRepository.saveToken(userId, deviceType, refreshTokenDTO);
+		tokenRepository.saveToken(userId, otherDeviceType, otherDeviceTokenDTO);
 
 		// Then
-		Optional<Token> mobileToken = tokenRepository.findToken(userId, deviceType);
-		Optional<Token> desktopToken = tokenRepository.findToken(userId, otherDeviceType);
+		TokenDTO mobileToken = tokenRepository.findToken(userId, deviceType);
+		TokenDTO desktopToken = tokenRepository.findToken(userId, otherDeviceType);
 
-		assertThat(mobileToken).isPresent();
-		assertThat(desktopToken).isPresent();
-		assertThat(mobileToken.get().getValue()).isEqualTo(refreshToken.getValue());
-		assertThat(desktopToken.get().getValue()).isEqualTo(otherDeviceToken.getValue());
+		assertThat(mobileToken).isNotNull();
+		assertThat(desktopToken).isNotNull();
+		assertThat(mobileToken.value()).isEqualTo(refreshToken.getValue());
+		assertThat(desktopToken.value()).isEqualTo(otherDeviceToken.getValue());
 
 		tokenRepository.removeToken(userId, deviceType);
 
-		assertThat(tokenRepository.findToken(userId, deviceType)).isEmpty();
-		assertThat(tokenRepository.findToken(userId, otherDeviceType)).isPresent();
+		assertThat(tokenRepository.findToken(userId, deviceType)).isNotNull();
+		assertThat(tokenRepository.findToken(userId, otherDeviceType)).isNotNull();
 	}
 }

--- a/src/test/java/com/newzet/api/auth/repository/RedisTokenRepositoryImplTest.java
+++ b/src/test/java/com/newzet/api/auth/repository/RedisTokenRepositoryImplTest.java
@@ -42,7 +42,7 @@ class RedisTokenRepositoryImplTest {
 	public void saveToken_storesTokenInRedis() {
 		//Given
 		String tokenValue = "token-value";
-		TokenDTO tokenDTO = TokenDTO.of(tokenValue);
+		TokenDTO tokenDTO = TokenDTO.from(tokenValue);
 		String expectedKey = "refreshToken:" + userId + ":" + deviceType;
 
 		//When
@@ -59,7 +59,7 @@ class RedisTokenRepositoryImplTest {
 	public void findToken_whenTokenExists_returnToken() {
 		//Given
 		String tokenValue = "token-value";
-		TokenDTO tokenDTO = TokenDTO.of(tokenValue);
+		TokenDTO tokenDTO = TokenDTO.from(tokenValue);
 		String expectedKey = "refreshToken:" + userId + ":" + deviceType;
 
 		when(valueOperations.get(expectedKey)).thenReturn(tokenValue);

--- a/src/test/java/com/newzet/api/auth/repository/RedisTokenRepositoryImplTest.java
+++ b/src/test/java/com/newzet/api/auth/repository/RedisTokenRepositoryImplTest.java
@@ -3,7 +3,6 @@ package com.newzet.api.auth.repository;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -16,9 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-import com.newzet.api.auth.business.service.JwtFactory;
-import com.newzet.api.auth.domain.Token;
-import com.newzet.api.auth.domain.TokenType;
+import com.newzet.api.auth.business.dto.TokenDTO;
 
 @ExtendWith(MockitoExtension.class)
 class RedisTokenRepositoryImplTest {
@@ -29,9 +26,6 @@ class RedisTokenRepositoryImplTest {
 	@Mock
 	private ValueOperations<String, String> valueOperations;
 
-	@Mock
-	private JwtFactory jwtFactory;
-
 	private RedisTokenRepositoryImpl tokenRepository;
 	private UUID userId;
 	private String deviceType;
@@ -39,7 +33,7 @@ class RedisTokenRepositoryImplTest {
 	@BeforeEach
 	void setUp() {
 		lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-		tokenRepository = new RedisTokenRepositoryImpl(redisTemplate, jwtFactory);
+		tokenRepository = new RedisTokenRepositoryImpl(redisTemplate);
 		userId = UUID.randomUUID();
 		deviceType = "web";
 	}
@@ -47,15 +41,15 @@ class RedisTokenRepositoryImplTest {
 	@Test
 	public void saveToken_storesTokenInRedis() {
 		//Given
-		Token token = Token.of(TokenType.REFRESH, "token-value", userId.toString(), new Date(),
-			new Date());
+		String tokenValue = "token-value";
+		TokenDTO tokenDTO = TokenDTO.of(tokenValue);
 		String expectedKey = "refreshToken:" + userId + ":" + deviceType;
 
 		//When
-		tokenRepository.saveToken(userId, deviceType, token);
+		tokenRepository.saveToken(userId, deviceType, tokenDTO);
 
 		//Then
-		verify(valueOperations).set(eq(expectedKey), eq(token.getValue()), anyLong(),
+		verify(valueOperations).set(eq(expectedKey), eq(tokenDTO.value()), anyLong(),
 			eq(TimeUnit.MILLISECONDS));
 		verify(valueOperations).set(startsWith("refresh-time:"), anyString(), anyLong(),
 			eq(TimeUnit.MILLISECONDS));
@@ -65,32 +59,29 @@ class RedisTokenRepositoryImplTest {
 	public void findToken_whenTokenExists_returnToken() {
 		//Given
 		String tokenValue = "token-value";
-		Token token = Token.of(TokenType.REFRESH, tokenValue, userId.toString(), new Date(),
-			new Date());
+		TokenDTO tokenDTO = TokenDTO.of(tokenValue);
 		String expectedKey = "refreshToken:" + userId + ":" + deviceType;
 
 		when(valueOperations.get(expectedKey)).thenReturn(tokenValue);
-		when(jwtFactory.parseToken(tokenValue)).thenReturn(Optional.of(token));
 
 		//When
-		Optional<Token> result = tokenRepository.findToken(userId, deviceType);
+		TokenDTO result = tokenRepository.findToken(userId, deviceType);
 
 		//Then
-		assertThat(result).isPresent();
-		assertThat(result.get()).isEqualTo(token);
+		assertThat(result.value()).isEqualTo(tokenDTO.value());
 	}
 
 	@Test
-	public void findToken_whenTokenDoesNotExist_returnEmpty() {
+	public void findToken_whenTokenDoesNotExist_returnNullToken() {
 		//Given
 		String expectedKey = "refreshToken:" + userId + ":" + deviceType;
 		when(valueOperations.get(expectedKey)).thenReturn(null);
 
 		//When
-		Optional<Token> result = tokenRepository.findToken(userId, deviceType);
+		TokenDTO result = tokenRepository.findToken(userId, deviceType);
 
 		//Then
-		assertThat(result).isEmpty();
+		assertThat(result.value()).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
# 개요
- Token 도메인과 repository단의 종속성 제거

# 배경
- 현재 Auth로직 하위의 비즈니스 로직의 Token 도메인과 Redis 저장용 Repository단의 소통이 Token도메인 자체를 매개체로 진행되고있음
- 실질적으로 Redis 저장 로직에서 필요한 Token 도메인 필드는 현재 value 뿐이라 필요 이상의 정보가 전달되고있음

# 변경된 점
- Repository와 비즈니스 로직의 Token을 통한 소통을 TokenRedisDTO로 변경
- TokenRepository의 Redis 구현체에서의 Token 의존성 및 비즈니스 로직의 JwtFactory 의존성 제거
- 도메인단의 토큰value 비교 및 TokenDTO로의 mapping 메서드 구현
- 관련 비즈니스 로직 및 repository로직 수정
- 관련 테스트코드 정상 통과하도록 수정

## 참고자료
x

## 관련 이슈

close #59 