### PR TITLE
Newsletter List 검색 API 분리

### DIFF
--- a/src/main/java/com/newzet/api/common/util/UuidConverter.java
+++ b/src/main/java/com/newzet/api/common/util/UuidConverter.java
@@ -6,7 +6,7 @@ import com.newzet.api.common.util.exception.UuidConvertFailException;
 
 public class UuidConverter {
 	public static UUID convert(String stringId) {
-		if (stringId == null || stringId.isEmpty()) {
+		if (stringId == null || stringId.isBlank()) {
 			throw new UuidConvertFailException("빈 값을 uuid로 변환할 수 없습니다.");
 		}
 

--- a/src/main/java/com/newzet/api/common/util/UuidConverter.java
+++ b/src/main/java/com/newzet/api/common/util/UuidConverter.java
@@ -6,13 +6,14 @@ import com.newzet.api.common.util.exception.UuidConvertFailException;
 
 public class UuidConverter {
 	public static UUID convert(String stringId) {
-		if (stringId != null && !stringId.isEmpty()) {
-			try {
-				return UUID.fromString(stringId);
-			} catch (IllegalArgumentException e) {
-				throw new UuidConvertFailException(e.getMessage());
-			}
+		if (stringId == null || stringId.isEmpty()) {
+			throw new UuidConvertFailException("빈 값을 uuid로 변환할 수 없습니다.");
 		}
-		return null;
+
+		try {
+			return UUID.fromString(stringId);
+		} catch (IllegalArgumentException e) {
+			throw new UuidConvertFailException(e.getMessage());
+		}
 	}
 }

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterRepository.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterRepository.java
@@ -12,7 +12,9 @@ public interface NewsletterRepository {
 
 	Optional<NewsletterEntityDto> findByDomainOrMailingList(String domain, String mailingList);
 
-	List<NewsletterEntityDto> findNewsLetterListByNameOrCategoryId(String name, UUID categoryId);
+	List<NewsletterEntityDto> findNewsLetterListByName(String name);
+
+	List<NewsletterEntityDto> findNewsLetterListByCategoryId(UUID categoryId);
 
 	NewsletterEntityDto getById(UUID id);
 

--- a/src/main/java/com/newzet/api/newsletter/business/service/NewsletterService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/service/NewsletterService.java
@@ -45,11 +45,22 @@ public class NewsletterService {
 			.orElseGet(() -> findOrCreateByDomainOrMailingListWithLock(name, domain, mailingList));
 	}
 
-	public NewsletterListResponse searchNewsletterListByNameOrCategoryId(String name,
-		String categoryId) {
-		UUID categoryUuid = UuidConverter.convert(categoryId);
-		List<NewsletterResponse> newsletterResponseList = newsletterRepository.findNewsLetterListByNameOrCategoryId(
-				name, categoryUuid).stream()
+	public NewsletterListResponse searchNewsletterListByName(String name) {
+		List<NewsletterResponse> newsletterResponseList = newsletterRepository.findNewsLetterListByName(
+				name).stream()
+			.map(newsletterEntity -> NewsletterResponse.create(newsletterEntity.getId(),
+				newsletterEntity.getName(), newsletterEntity.getImageUrl(),
+				newsletterEntity.getDescription(), newsletterEntity.getPriority()))
+			.toList();
+
+		return NewsletterListResponse.create(newsletterResponseList);
+	}
+
+	public NewsletterListResponse getNewsletterListByCategoryId(String categoryId) {
+		UUID categoryIdUuid = UuidConverter.convert(categoryId);
+
+		List<NewsletterResponse> newsletterResponseList = newsletterRepository.findNewsLetterListByCategoryId(
+				categoryIdUuid).stream()
 			.map(newsletterEntity -> NewsletterResponse.create(newsletterEntity.getId(),
 				newsletterEntity.getName(), newsletterEntity.getImageUrl(),
 				newsletterEntity.getDescription(), newsletterEntity.getPriority()))
@@ -67,7 +78,6 @@ public class NewsletterService {
 			newsletter.getDayOfWeek(), newsletter.getSubscriptionUrl(), false,
 			newsletter.getCategory().getName());
 	}
-
 
 	private Optional<Newsletter> findByDomainOnCache(String domain) {
 		return cacheUtil.get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class)

--- a/src/main/java/com/newzet/api/newsletter/controller/NewsletterController.java
+++ b/src/main/java/com/newzet/api/newsletter/controller/NewsletterController.java
@@ -32,13 +32,25 @@ public class NewsletterController {
 	private final NewsletterRecommendationService newsletterRecommendationService;
 
 	@GetMapping("/search")
+	@Operation(summary = "뉴스레터 검색",
+		description = "뉴스레터 이름으로 뉴스테러를 검색한다.")
+	public ResponseEntity<SuccessResponse<NewsletterListResponse>> getNewsletterListByName(
+		@RequestParam(value = "name") String name) {
+		NewsletterListResponse newsletterListResponse = newsletterService.searchNewsletterListByName(
+			name);
+		SuccessResponse<NewsletterListResponse> response = SuccessResponse.create(
+			ResponseCode.SUCCESS, "뉴스레터 목록 조회 성공", newsletterListResponse);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping
 	@Operation(summary = "뉴스레터 리스트 조회",
-		description = "뉴스레터 이름 혹은 카테고리 id로 뉴스테러 리스트를 조회한다.")
-	public ResponseEntity<SuccessResponse<NewsletterListResponse>> getNewsletterListByNameOrCategoryId(
-		@RequestParam(value = "name", required = false) String name,
-		@RequestParam(value = "categoryId", required = false) String categoryId) {
-		NewsletterListResponse newsletterListResponse = newsletterService.searchNewsletterListByNameOrCategoryId(
-			name, categoryId);
+		description = "뉴스레터 카테고리 id로 뉴스테러 리스트를 조회한다.")
+	public ResponseEntity<SuccessResponse<NewsletterListResponse>> getNewsletterListByCategoryId(
+		@RequestParam(value = "categoryId") String categoryId) {
+		NewsletterListResponse newsletterListResponse = newsletterService.getNewsletterListByCategoryId(
+			categoryId);
 		SuccessResponse<NewsletterListResponse> response = SuccessResponse.create(
 			ResponseCode.SUCCESS, "뉴스레터 목록 조회 성공", newsletterListResponse);
 

--- a/src/main/java/com/newzet/api/newsletter/repository/NewsletterJpaRepository.java
+++ b/src/main/java/com/newzet/api/newsletter/repository/NewsletterJpaRepository.java
@@ -13,7 +13,9 @@ public interface NewsletterJpaRepository extends JpaRepository<NewsletterEntity,
 	Optional<NewsletterEntity> findNewsletterByDomainOrMailingList(String domain,
 		String mailingList);
 
-	List<NewsletterEntity> findNewsletterListByNameOrCategoryId(String name, UUID categoryId);
+	List<NewsletterEntity> findNewsletterListByName(String name);
+
+	List<NewsletterEntity> findNewsletterListByCategoryId(UUID categoryId);
 
 	@Query("select n from NewsletterEntity n where n.category.id in :categoryIdList")
 	List<NewsletterEntity> findByCategoryIdList(List<UUID> categoryIdList);

--- a/src/main/java/com/newzet/api/newsletter/repository/NewsletterRepositoryImpl.java
+++ b/src/main/java/com/newzet/api/newsletter/repository/NewsletterRepositoryImpl.java
@@ -33,9 +33,15 @@ public class NewsletterRepositoryImpl implements NewsletterRepository {
 	}
 
 	@Override
-	public List<NewsletterEntityDto> findNewsLetterListByNameOrCategoryId(String name,
-		UUID categoryId) {
-		return newsletterJpaRepository.findNewsletterListByNameOrCategoryId(name, categoryId).stream()
+	public List<NewsletterEntityDto> findNewsLetterListByName(String name) {
+		return newsletterJpaRepository.findNewsletterListByName(name).stream()
+			.map(NewsletterEntity::toEntityDto)
+			.toList();
+	}
+
+	@Override
+	public List<NewsletterEntityDto> findNewsLetterListByCategoryId(UUID categoryId) {
+		return newsletterJpaRepository.findNewsletterListByCategoryId(categoryId).stream()
 			.map(NewsletterEntity::toEntityDto)
 			.toList();
 	}

--- a/src/test/java/com/newzet/api/common/util/UuidConverterTest.java
+++ b/src/test/java/com/newzet/api/common/util/UuidConverterTest.java
@@ -1,0 +1,53 @@
+package com.newzet.api.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.newzet.api.common.util.exception.UuidConvertFailException;
+
+class UuidConverterTest {
+
+	private static final String uuid = UUID.randomUUID().toString();
+
+	private static Stream<Arguments> invalidUuidString() {
+		return Stream.of(
+			Arguments.of(" "),
+			Arguments.of("invalid-uuid"),
+			Arguments.of(uuid + " "),
+			Arguments.of(" " + uuid),
+			Arguments.of(uuid + "1"),
+			Arguments.of(uuid + "a")
+		);
+	}
+
+	@Test
+	void success_on_valid_uuid_string() {
+		UUID convertedUuid = UuidConverter.convert(uuid);
+
+		assertThat(convertedUuid.toString()).isEqualTo(uuid);
+	}
+
+	@ParameterizedTest
+	@MethodSource("invalidUuidString")
+	void fail_on_invalid_uuid_string(String value) {
+		assertThatThrownBy(() -> UuidConverter.convert(value)).isInstanceOf(
+			UuidConvertFailException.class);
+	}
+
+	@Test
+	void fail_on_empty_string() {
+		assertThatThrownBy(() -> UuidConverter.convert(null)).isInstanceOf(
+			UuidConvertFailException.class).hasMessage("빈 값을 uuid로 변환할 수 없습니다.");
+
+		assertThatThrownBy(() -> UuidConverter.convert("")).isInstanceOf(
+			UuidConvertFailException.class).hasMessage("빈 값을 uuid로 변환할 수 없습니다.");
+	}
+
+}

--- a/src/test/java/com/newzet/api/common/util/UuidConverterTest.java
+++ b/src/test/java/com/newzet/api/common/util/UuidConverterTest.java
@@ -1,6 +1,7 @@
 package com.newzet.api.common.util;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -18,6 +19,8 @@ class UuidConverterTest {
 
 	private static Stream<Arguments> invalidUuidString() {
 		return Stream.of(
+			null,
+			Arguments.of(""),
 			Arguments.of(" "),
 			Arguments.of("invalid-uuid"),
 			Arguments.of(uuid + " "),
@@ -31,7 +34,7 @@ class UuidConverterTest {
 	void success_on_valid_uuid_string() {
 		UUID convertedUuid = UuidConverter.convert(uuid);
 
-		assertThat(convertedUuid.toString()).isEqualTo(uuid);
+		assertEquals(uuid, convertedUuid.toString());
 	}
 
 	@ParameterizedTest
@@ -39,15 +42,6 @@ class UuidConverterTest {
 	void fail_on_invalid_uuid_string(String value) {
 		assertThatThrownBy(() -> UuidConverter.convert(value)).isInstanceOf(
 			UuidConvertFailException.class);
-	}
-
-	@Test
-	void fail_on_empty_string() {
-		assertThatThrownBy(() -> UuidConverter.convert(null)).isInstanceOf(
-			UuidConvertFailException.class).hasMessage("빈 값을 uuid로 변환할 수 없습니다.");
-
-		assertThatThrownBy(() -> UuidConverter.convert("")).isInstanceOf(
-			UuidConvertFailException.class).hasMessage("빈 값을 uuid로 변환할 수 없습니다.");
 	}
 
 }

--- a/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
+++ b/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
@@ -20,7 +20,6 @@ import com.newzet.api.common.cache.CacheUtil;
 import com.newzet.api.common.exception.InternalErrorException;
 import com.newzet.api.common.lock.LockFactory;
 import com.newzet.api.common.lock.exception.LocalLockAcquisitionException;
-import com.newzet.api.common.util.exception.UuidConvertFailException;
 import com.newzet.api.newsletter.business.dto.NewsletterCacheDto;
 import com.newzet.api.newsletter.business.dto.NewsletterEntityDto;
 import com.newzet.api.newsletter.business.service.NewsletterService;
@@ -152,50 +151,6 @@ class NewsletterServiceTest {
 		assertEquals(1, searchList.newsletterList().size());
 	}
 
-	@Test
-	public void getNewsletterListByCategoryId_whenCategoryIdIsNull() {
-		// Given
-		NewsletterEntityDto newsletter = NewsletterFixture.createEntityWithId().toEntityDto();
-		List<NewsletterEntityDto> newsletterList = new ArrayList<>();
-		newsletterList.add(newsletter);
-		when(newsletterRepository.findNewsLetterListByCategoryId(
-			nullable(UUID.class)))
-			.thenReturn(newsletterList);
-
-		// When
-		NewsletterListResponse searchList = newsletterService.getNewsletterListByCategoryId(null);
-
-		// Then
-		verify(newsletterRepository, times(1)).findNewsLetterListByCategoryId(
-			nullable(UUID.class));
-		assertEquals(1, searchList.newsletterList().size());
-	}
-
-	@Test
-	public void getNewsletterListByCategoryId_whenCategoryIdEmpty() {
-		// Given
-		NewsletterEntityDto newsletter = NewsletterFixture.createEntityWithId().toEntityDto();
-		List<NewsletterEntityDto> newsletterList = new ArrayList<>();
-		newsletterList.add(newsletter);
-		when(newsletterRepository.findNewsLetterListByCategoryId(
-			nullable(UUID.class)))
-			.thenReturn(newsletterList);
-
-		// When
-		NewsletterListResponse searchList = newsletterService.getNewsletterListByCategoryId("");
-
-		// Then
-		verify(newsletterRepository, times(1)).findNewsLetterListByCategoryId(
-			nullable(UUID.class));
-		assertEquals(1, searchList.newsletterList().size());
-	}
-
-	@Test
-	public void getNewsletterListByCategoryId_Invalid_CategoryId_throwException() {
-		// When Then
-		assertThrows(UuidConvertFailException.class,
-			() -> newsletterService.getNewsletterListByCategoryId("wrong uuid"));
-	}
 
 	@Test
 	public void getNewsletterById() {

--- a/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
+++ b/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceTest.java
@@ -134,71 +134,67 @@ class NewsletterServiceTest {
 	}
 
 	@Test
-	public void searchNewsletterListByNameOrCategoryId() {
+	public void searchNewsletterListByName() {
 		// Given
 		NewsletterEntityDto newsletter = NewsletterFixture.createEntityWithId().toEntityDto();
 		List<NewsletterEntityDto> newsletterList = new ArrayList<>();
 		newsletterList.add(newsletter);
-		when(newsletterRepository.findNewsLetterListByNameOrCategoryId(any(String.class),
-			any(UUID.class)))
+		when(newsletterRepository.findNewsLetterListByName(any(String.class)))
 			.thenReturn(newsletterList);
 
 		// When
-		NewsletterListResponse searchList = newsletterService.searchNewsletterListByNameOrCategoryId(
-			newsletter.getName(), String.valueOf(categoryEntity.getId()));
+		NewsletterListResponse searchList = newsletterService.searchNewsletterListByName(
+			newsletter.getName());
 
 		// Then
-		verify(newsletterRepository, times(1)).findNewsLetterListByNameOrCategoryId(
-			any(String.class), any(UUID.class));
+		verify(newsletterRepository, times(1)).findNewsLetterListByName(
+			any(String.class));
 		assertEquals(1, searchList.newsletterList().size());
 	}
 
 	@Test
-	public void searchNewsletterListByNameOrCategoryId_whenCategoryIdIsNull() {
+	public void getNewsletterListByCategoryId_whenCategoryIdIsNull() {
 		// Given
 		NewsletterEntityDto newsletter = NewsletterFixture.createEntityWithId().toEntityDto();
 		List<NewsletterEntityDto> newsletterList = new ArrayList<>();
 		newsletterList.add(newsletter);
-		when(newsletterRepository.findNewsLetterListByNameOrCategoryId(any(String.class),
+		when(newsletterRepository.findNewsLetterListByCategoryId(
 			nullable(UUID.class)))
 			.thenReturn(newsletterList);
 
 		// When
-		NewsletterListResponse searchList = newsletterService.searchNewsletterListByNameOrCategoryId(
-			newsletter.getName(), null);
+		NewsletterListResponse searchList = newsletterService.getNewsletterListByCategoryId(null);
 
 		// Then
-		verify(newsletterRepository, times(1)).findNewsLetterListByNameOrCategoryId(
-			any(String.class), nullable(UUID.class));
+		verify(newsletterRepository, times(1)).findNewsLetterListByCategoryId(
+			nullable(UUID.class));
 		assertEquals(1, searchList.newsletterList().size());
 	}
 
 	@Test
-	public void searchNewsletterListByNameOrCategoryId_whenCategoryIdEmpty() {
+	public void getNewsletterListByCategoryId_whenCategoryIdEmpty() {
 		// Given
 		NewsletterEntityDto newsletter = NewsletterFixture.createEntityWithId().toEntityDto();
 		List<NewsletterEntityDto> newsletterList = new ArrayList<>();
 		newsletterList.add(newsletter);
-		when(newsletterRepository.findNewsLetterListByNameOrCategoryId(any(String.class),
+		when(newsletterRepository.findNewsLetterListByCategoryId(
 			nullable(UUID.class)))
 			.thenReturn(newsletterList);
 
 		// When
-		NewsletterListResponse searchList = newsletterService.searchNewsletterListByNameOrCategoryId(
-			newsletter.getName(), "");
+		NewsletterListResponse searchList = newsletterService.getNewsletterListByCategoryId("");
 
 		// Then
-		verify(newsletterRepository, times(1)).findNewsLetterListByNameOrCategoryId(
-			any(String.class), nullable(UUID.class));
+		verify(newsletterRepository, times(1)).findNewsLetterListByCategoryId(
+			nullable(UUID.class));
 		assertEquals(1, searchList.newsletterList().size());
 	}
 
 	@Test
-	public void searchNewsletterListByNameOrCategoryId_Invalid_CategoryId_throwException() {
+	public void getNewsletterListByCategoryId_Invalid_CategoryId_throwException() {
 		// When Then
 		assertThrows(UuidConvertFailException.class,
-			() -> newsletterService.searchNewsletterListByNameOrCategoryId(
-				"test", "wrong uuid"));
+			() -> newsletterService.getNewsletterListByCategoryId("wrong uuid"));
 	}
 
 	@Test

--- a/src/test/java/com/newzet/api/newsletter/repository/NewsletterRepositoryImplTest.java
+++ b/src/test/java/com/newzet/api/newsletter/repository/NewsletterRepositoryImplTest.java
@@ -147,7 +147,7 @@ class NewsletterRepositoryImplTest {
 		assertEquals(newsletterList.get(0).getName(), newsletter.getName());
 		assertEquals(category.getId(), newsletter.getCategory().getId());
 	}
-	
+
 
 	@Test
 	public void getNewsletterById() {

--- a/src/test/java/com/newzet/api/newsletter/repository/NewsletterRepositoryImplTest.java
+++ b/src/test/java/com/newzet/api/newsletter/repository/NewsletterRepositoryImplTest.java
@@ -117,13 +117,13 @@ class NewsletterRepositoryImplTest {
 	}
 
 	@Test
-	public void findNewsletterListByNameOrCategoryId_WithName() {
+	public void findNewsletterListByName_WithName() {
 		//Given
 		NewsletterEntityDto savedNewsletter = saveNewsletter();
 
 		//When
-		List<NewsletterEntityDto> newsletterList = newsletterRepository.findNewsLetterListByNameOrCategoryId(
-			savedNewsletter.getName(), null);
+		List<NewsletterEntityDto> newsletterList = newsletterRepository.findNewsLetterListByName(
+			savedNewsletter.getName());
 
 		//Then
 		assertEquals(1, newsletterList.size());
@@ -131,7 +131,7 @@ class NewsletterRepositoryImplTest {
 	}
 
 	@Test
-	public void findNewsletterListByNameOrCategoryId_WithCategoryId() {
+	public void findNewsletterListByCategoryId_WithCategoryId() {
 		//Given
 		CategoryEntity category = categoryJpaRepository.save(
 			CategoryEntity.create("testCategory", "test", "test"));
@@ -139,32 +139,15 @@ class NewsletterRepositoryImplTest {
 			NewsletterFixture.createDefaultEntity(category));
 
 		//When
-		List<NewsletterEntityDto> newsletterList = newsletterRepository.findNewsLetterListByNameOrCategoryId(
-			null, category.getId());
+		List<NewsletterEntityDto> newsletterList = newsletterRepository.findNewsLetterListByCategoryId(
+			category.getId());
 
 		//Then
 		assertEquals(1, newsletterList.size());
 		assertEquals(newsletterList.get(0).getName(), newsletter.getName());
 		assertEquals(category.getId(), newsletter.getCategory().getId());
 	}
-
-	@Test
-	public void findNewsletterListByNameOrCategoryId_WithName_andCategoryId() {
-		//Given
-		CategoryEntity category = categoryJpaRepository.save(
-			CategoryEntity.create("testCategory", "test", "test"));
-		NewsletterEntity newsletter = newsletterJpaRepository.save(
-			NewsletterFixture.createDefaultEntity(category));
-
-		//When
-		List<NewsletterEntityDto> newsletterList = newsletterRepository.findNewsLetterListByNameOrCategoryId(
-			newsletter.getName(), category.getId());
-
-		//Then
-		assertEquals(1, newsletterList.size());
-		assertEquals(newsletterList.get(0).getName(), newsletter.getName());
-		assertEquals(category.getId(), newsletter.getCategory().getId());
-	}
+	
 
 	@Test
 	public void getNewsletterById() {


### PR DESCRIPTION
# 개요

- Newsletter List 검색 배타 조건(name, categoryId 둘 중 하나로 조회)으로 구현된 API 분리

# 배경

- 기존 Newsletter 리스트 조회 API는 name과 categoryId 중 하나를 쿼리 파라미터로 가질 수 있음, 두 별개의 조건을 하나의 API로 통일하여 사용할 수 있는 구조를 유지하고 있었음
- name은 유저가 뉴스레터 이름을 검색하여 리스트를 조회하는 면에서 'search'가 적절하나, categoryId는 유저가 카테고리를 클릭했을때 해당 카테고리의 리스트를 조회한다는 면에서 'search'와 결이 다름
- 따라서 둘을 별개의 API로 분리하기로 결정함, 반환 양식은 동일한 구조를 가짐

# 변경된 점

- 뉴스레터 이름으로 뉴스레터를 검색하는 API와, 뉴스레터의 카테고리 id로 뉴스레터를 조회하는 API 각각 분리
- UuidConverter null/빈 입력 검사 및 예외 처리 로직 추가
  - 관련 테스트 코드 작성

## 참고자료
- 뉴스레터 이름으로 검색 API 구성
  <img width="1714" alt="스크린샷 2025-05-09 오후 9 26 51" src="https://github.com/user-attachments/assets/f2ffb75b-700b-44a9-8bed-01954a211e8e" />

- 뉴스레터 카테고리 id로 조회 API 구성
  <img width="1730" alt="스크린샷 2025-05-09 오후 9 25 21" src="https://github.com/user-attachments/assets/1e5b8ba1-e735-4bcf-98f7-4ee9eb93ed6e" />

## 관련 이슈

close #66
