### PR TITLE
애노테이션 기반 도메인 AOP 로깅 기능 구현

### DIFF
--- a/src/main/java/com/newzet/api/common/logging/LogExecution.java
+++ b/src/main/java/com/newzet/api/common/logging/LogExecution.java
@@ -1,0 +1,11 @@
+package com.newzet.api.common.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecution {
+}

--- a/src/main/java/com/newzet/api/common/logging/LoggingAspect.java
+++ b/src/main/java/com/newzet/api/common/logging/LoggingAspect.java
@@ -19,19 +19,19 @@ public class LoggingAspect {
 	public void servicePointcut() {
 	}
 
-	// @Pointcut("execution(* com.newzet..api..domain..*.*(..))")
-	// public void domainPointcut() {
-	// }
-
 	@Pointcut("execution(* com.newzet..api..repository..*RepositoryImpl.*(..))")
 	public void repositoryPointcut() {
 	}
 
 	@Pointcut("execution(* com.newzet..api.common.lock..*LockFactory.*(..))")
-	public void LockFactoryPointcut() {
+	public void lockFactoryPointcut() {
 	}
 
-	@AfterThrowing(pointcut = "servicePointcut() || repositoryPointcut() || LockFactoryPointcut()", throwing = "e")
+	@Pointcut("@annotation(com.newzet.api.common.logging.LogExecution)")
+	public void logExecutionPointcut() {
+	}
+
+	@AfterThrowing(pointcut = "servicePointcut() || repositoryPointcut() || lockFactoryPointcut() || logExecutionPointcut()", throwing = "e")
 	public void logException(JoinPoint joinPoint, Throwable e) {
 		String method = joinPoint.getSignature().toShortString();
 		String args = Arrays.toString(joinPoint.getArgs());

--- a/src/main/java/com/newzet/api/newsletter/domain/service/NewsletterRecommender.java
+++ b/src/main/java/com/newzet/api/newsletter/domain/service/NewsletterRecommender.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.newzet.api.common.logging.LogExecution;
 import com.newzet.api.newsletter.business.exception.NotEnoughNewslettersException;
 import com.newzet.api.newsletter.domain.model.Newsletter;
 import com.newzet.api.newsletter.domain.strategy.RecommendationStrategy;
@@ -36,6 +37,7 @@ public class NewsletterRecommender {
 		return recommendedNewsletterList;
 	}
 
+	@LogExecution
 	private int getRemainingQuarter(int filledQuarter, int size) {
 		int resQuarter = RECOMMENDATION_QUARTER_SIZE - filledQuarter;
 		if (size < resQuarter) {


### PR DESCRIPTION
# 개요

- 도메인 계층에서 발생하는 예외에 대한 로깅을 적용시키기 위해, 애노테이션 기반 AOP 로깅을 구현한다.

# 배경

- 현재 AOP 로깅의 범위는 리포지토리, 서비스 계층에 한정되어 있음
- 주요 비즈니스 로직이 포함되는 도메인 계층에도 로깅의 필요성을 느낌
- 기존에 도메인 계층에 대해 포인트컷을 적용하지 않은 이유?
  - 도메인 전체를 대상으로 포인트컷을 적용하면, 도메인의 생성자/Getter 등과 같은 메서드에도 AOP가 작동하여 성능 저하의 이슈가 있기 때문에 적용하지 않았었음

# 변경된 점

- 도메인의 모든 메서드에 AOP 적용 대상으로 설정하는 것은, 성능 상 좋지 못하므로 애노테이션 기반 AOP 로깅을 도입
- @LogExecution을 메서드에 선언하면 로깅 AOP가 적용됨
- 로깅이 필요한 메서드에만 선택적으로 적용 가능(기존 비즈니스 계층 Service/인프라 계층 Repository는 포인트컷이 적용되어 있으므로 추가 작성할 필요 x)
```java
        @LogExecution
	private int getRemainingQuarter(int filledQuarter, int size) {
		int resQuarter = RECOMMENDATION_QUARTER_SIZE - filledQuarter;
		if (size < resQuarter) {
			throw new NotEnoughNewslettersException("추천할 뉴스레터 count 수보다 존재하는 뉴스레터 수가 적습니다.");
		}
		return resQuarter;
	}
```

## 참고자료

## 관련 이슈

close #68 
