### PR TITLE
예외 로깅 ExceptionHandler에서 수행하도록 변경

### DIFF
--- a/src/main/java/com/newzet/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/newzet/api/common/exception/GlobalExceptionHandler.java
@@ -13,12 +13,24 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GlobalExceptionHandler {
 
+	private static void printLogForException(Exception e) {
+		StackTraceElement origin = e.getStackTrace()[0];
+		log.error("[예외 발생] 클래스: {} / 메서드: {}\n[메시지] {}\n[스택-트레이스]",
+			origin.getClassName(),
+			origin.getMethodName(),
+			e.getMessage(),
+			e
+		);
+	}
+
 	@ExceptionHandler(NewzetException.class)
 	public ProblemDetail handleNewzetEx(NewzetException e) {
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.OK);
 		problemDetail.setTitle("Newzet Service Error");
 		problemDetail.setProperty("code", e.getResponseCode().getCode());
 		problemDetail.setProperty("message", e.getMessage());
+
+		printLogForException(e);
 		return problemDetail;
 	}
 
@@ -28,6 +40,8 @@ public class GlobalExceptionHandler {
 		problemDetail.setTitle("Internal Error");
 		problemDetail.setProperty("code", ResponseCode.SERVER_ERROR);
 		problemDetail.setProperty("message", "내부에서 요청 처리에 실패하였습니다. 다시 시도해주세요.");
+
+		printLogForException(e);
 		return problemDetail;
 	}
 
@@ -36,7 +50,10 @@ public class GlobalExceptionHandler {
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.OK);
 		problemDetail.setTitle("Unknown Error");
 		problemDetail.setProperty("code", ResponseCode.SERVER_ERROR);
-		problemDetail.setProperty("message", "알 수 없는 서버 내부 오류가 발생하였습니다, Exception Class=" + e.getClass().getSimpleName());
+		problemDetail.setProperty("message",
+			"알 수 없는 서버 내부 오류가 발생하였습니다, Exception Class=" + e.getClass().getSimpleName());
+
+		printLogForException(e);
 		return problemDetail;
 	}
 }

--- a/src/main/java/com/newzet/api/common/logging/LoggingAspect.java
+++ b/src/main/java/com/newzet/api/common/logging/LoggingAspect.java
@@ -1,46 +1,36 @@
 package com.newzet.api.common.logging;
 
-import java.util.Arrays;
-
-import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.AfterThrowing;
-import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Pointcut;
-import org.springframework.stereotype.Component;
-
-import lombok.extern.slf4j.Slf4j;
-
-@Aspect
-@Component
-@Slf4j
+// @Aspect
+// @Component
+// @Slf4j
 public class LoggingAspect {
 
-	@Pointcut("execution(* com.newzet..api..business..*Service.*(..))")
-	public void servicePointcut() {
-	}
-
-	// @Pointcut("execution(* com.newzet..api..domain..*.*(..))")
-	// public void domainPointcut() {
+	// @Pointcut("execution(* com.newzet..api..business..*Service.*(..))")
+	// public void servicePointcut() {
 	// }
-
-	@Pointcut("execution(* com.newzet..api..repository..*RepositoryImpl.*(..))")
-	public void repositoryPointcut() {
-	}
-
-	@Pointcut("execution(* com.newzet..api.common.lock..*LockFactory.*(..))")
-	public void LockFactoryPointcut() {
-	}
-
-	@AfterThrowing(pointcut = "servicePointcut() || repositoryPointcut() || LockFactoryPointcut()", throwing = "e")
-	public void logException(JoinPoint joinPoint, Throwable e) {
-		String method = joinPoint.getSignature().toShortString();
-		String args = Arrays.toString(joinPoint.getArgs());
-
-		log.error("[예외 발생] 메서드: {} / 파라미터: {}\n[메시지] {}\n[스택-트레이스]",
-			method,
-			args,
-			e.getMessage(),
-			e
-		);
-	}
+	//
+	// // @Pointcut("execution(* com.newzet..api..domain..*.*(..))")
+	// // public void domainPointcut() {
+	// // }
+	//
+	// @Pointcut("execution(* com.newzet..api..repository..*RepositoryImpl.*(..))")
+	// public void repositoryPointcut() {
+	// }
+	//
+	// @Pointcut("execution(* com.newzet..api.common.lock..*LockFactory.*(..))")
+	// public void LockFactoryPointcut() {
+	// }
+	//
+	// @AfterThrowing(pointcut = "servicePointcut() || repositoryPointcut() || LockFactoryPointcut()", throwing = "e")
+	// public void logException(JoinPoint joinPoint, Throwable e) {
+	// 	String method = joinPoint.getSignature().toShortString();
+	// 	String args = Arrays.toString(joinPoint.getArgs());
+	//
+	// 	log.error("[예외 발생] 메서드: {} / 파라미터: {}\n[메시지] {}\n[스택-트레이스]",
+	// 		method,
+	// 		args,
+	// 		e.getMessage(),
+	// 		e
+	// 	);
+	// }
 }


### PR DESCRIPTION
# 개요

- 예외 로깅 관련 리팩토링 작업

# 배경

- 기존에는 LoggingAspect라는 AOP 클래스에서 특정 계층에 포인트컷을 적용하여 예외를 로깅하였음
- 예외를 catch하여 처리하는 곳이 Presentation 계층의 ExceptionHandler이기 때문에, AOP 클래스를 도입하는 것도 좋지만 해당 위치에서 예외를 로깅하는게 더 자연스럽다고 판단하였음
- 덤으로 도메인 계층의 메서드에 AOP 로깅을 적용하는 애노테이션을 일일히 명시하는 것도 번거롭고 개발 과정에서 이를 빠뜨릴 리스크가 크다고 판단함

# 변경된 점

- 예외 로깅을 AOP 대신 ExceptionHandler에서 수행하도록 변경

## 참고자료
- 로깅 출력 예시
  ```java
  2025-06-04T16:28:32.139+09:00 ERROR 92832 --- [nio-8080-exec-1] c.n.a.c.e.GlobalExceptionHandler         : [예외 발생] 클래스: com.newzet.api.user.repository.repository.UserRepositoryImpl / 메서드: lambda$getByEmail$2
  [메시지] 사용자를 찾을 수 없습니다.
  [스택-트레이스]
  
  com.newzet.api.user.exception.NoUserException: 사용자를 찾을 수 없습니다.
	  at com.newzet.api.user.repository.repository.UserRepositoryImpl.lambda$getByEmail$2(UserRepositoryImpl.java:46) ~[main/:na]
	  at java.base/java.util.Optional.orElseThrow(Optional.java:403) ~[na:na]
	  at com.newzet.api.user.repository.repository.UserRepositoryImpl.getByEmail(UserRepositoryImpl.java:46) ~[main/:na]
	  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~
  ...
  ```
## 관련 이슈

close #81
