### PR TITLE
FCM 알림 전송 비동기 배치처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ out/
 /dockercomposes/monitoring/newrelic-infra/newrelic-infra.yml
 
 push.sh
+
+firebase-service-account.json

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // FCM 추가
+    implementation 'com.google.firebase:firebase-admin:9.5.0'
 }
 
 test {

--- a/src/main/java/com/newzet/api/article/business/batch/ArticleBatchConsumer.java
+++ b/src/main/java/com/newzet/api/article/business/batch/ArticleBatchConsumer.java
@@ -1,0 +1,6 @@
+package com.newzet.api.article.business.batch;
+
+import com.newzet.api.common.batch.BatchConsumer;
+
+public interface ArticleBatchConsumer extends BatchConsumer {
+}

--- a/src/main/java/com/newzet/api/article/business/batch/ArticleBatchProducer.java
+++ b/src/main/java/com/newzet/api/article/business/batch/ArticleBatchProducer.java
@@ -1,0 +1,7 @@
+package com.newzet.api.article.business.batch;
+
+import com.newzet.api.article.domain.Article;
+import com.newzet.api.common.batch.BatchProducer;
+
+public interface ArticleBatchProducer extends BatchProducer<Article> {
+}

--- a/src/main/java/com/newzet/api/article/business/service/ArticleService.java
+++ b/src/main/java/com/newzet/api/article/business/service/ArticleService.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.newzet.api.article.business.batch.ArticleBatchProducer;
 import com.newzet.api.article.business.repository.ArticleRepository;
 import com.newzet.api.article.controller.dto.ArticleContentResponse;
 import com.newzet.api.article.controller.dto.ArticleDetailResponse;
@@ -15,7 +16,6 @@ import com.newzet.api.article.controller.dto.ArticleListResponse;
 import com.newzet.api.article.controller.dto.DailyArticleResponse;
 import com.newzet.api.article.domain.Article;
 import com.newzet.api.article.repository.dto.ArticleWithImageProjection;
-import com.newzet.api.common.batch.BatchProducer;
 import com.newzet.api.common.util.UuidConverter;
 
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ArticleService {
 
-	private final BatchProducer batchProducer;
+	private final ArticleBatchProducer batchProducer;
 	private final ArticleRepository articleRepository;
 
 	public void saveArticleBatch(UUID userId, String fromName, String fromDomain,
@@ -67,7 +67,8 @@ public class ArticleService {
 	}
 
 	// 반환된 dto의 정렬된 순서를 유지하면서, day 별로 DailyArticleResponse를 묶음
-	private List<DailyArticleResponse> getDailyArticleList(List<ArticleDetailResponse> articleDetailResponseList) {
+	private List<DailyArticleResponse> getDailyArticleList(
+		List<ArticleDetailResponse> articleDetailResponseList) {
 		return articleDetailResponseList.stream()
 			.collect(Collectors.groupingBy(
 				ArticleDetailResponse::getDay,

--- a/src/main/java/com/newzet/api/article/controller/ArticleBatchController.java
+++ b/src/main/java/com/newzet/api/article/controller/ArticleBatchController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.newzet.api.common.batch.BatchConsumer;
+import com.newzet.api.article.business.batch.ArticleBatchConsumer;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,17 +20,17 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Article Batch", description = "[관리자용] 아티클 배치 처리 관련 API")
 public class ArticleBatchController {
 
-	private final BatchConsumer batchConsumer;
+	private final ArticleBatchConsumer batchConsumer;
 
 	@GetMapping("/status")
-	@Operation(summary = "[관리자용] 배치 처리 상태 조회",
+	@Operation(summary = "[관리자용] article 배치 처리 상태 조회",
 		description = "현재 배치 처리 상태와 대기 중인 메시지 수를 조회합니다.")
 	public ResponseEntity<Map<String, Object>> getBatchStatus() {
 		return ResponseEntity.ok(batchConsumer.getBatchStatus());
 	}
 
 	@PostMapping("/restart")
-	@Operation(summary = "[관리자용] 배치 처리 재시작",
+	@Operation(summary = "[관리자용] article 배치 처리 재시작",
 		description = "배치 처리를 중지하고 다시 시작합니다.")
 	public ResponseEntity<String> restartBatchProcessing() {
 		batchConsumer.stopProcessing();

--- a/src/main/java/com/newzet/api/article/controller/dto/ArticleDetailResponse.java
+++ b/src/main/java/com/newzet/api/article/controller/dto/ArticleDetailResponse.java
@@ -12,8 +12,10 @@ public record ArticleDetailResponse(
 	String createdAt
 ) {
 
-	public static ArticleDetailResponse of(UUID id, String newsletterName, String newsletterImgUrl, String title, boolean isRead, LocalDateTime createdAt) {
-		return new ArticleDetailResponse(id.toString(), newsletterName, newsletterImgUrl, title, isRead, createdAt.toString());
+	public static ArticleDetailResponse of(UUID id, String newsletterName, String newsletterImgUrl,
+		String title, boolean isRead, LocalDateTime createdAt) {
+		return new ArticleDetailResponse(id.toString(), newsletterName, newsletterImgUrl, title,
+			isRead, createdAt.toString());
 	}
 
 	public int getDay() {

--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleBatchConfig.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleBatchConfig.java
@@ -4,7 +4,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.newzet.api.common.batch.BatchConsumer;
+import com.newzet.api.article.business.batch.ArticleBatchConsumer;
 import com.newzet.api.common.batch.config.BatchConfig;
 
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ArticleBatchConfig {
 
-	private final BatchConsumer batchConsumer;
+	private final ArticleBatchConsumer batchConsumer;
 	private final BatchConfig batchConfig;
 
 	@Bean

--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
@@ -20,7 +20,7 @@ import com.newzet.api.article.repository.batch.dto.BatchSaveData;
 import com.newzet.api.common.batch.RedisBatchConsumer;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
-import com.newzet.api.fcm.orchestrator.FcmTokenOrchestrator;
+import com.newzet.api.fcm.orchestrator.FcmSenderOrchestrator;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,17 +36,17 @@ public class ArticleRedisBatchConsumerImpl extends RedisBatchConsumer<Article>
 	private static final long DUPLICATE_CACHE_TTL_MINUTES = 10;
 
 	private final ArticleRepository articleRepository;
-	private final FcmTokenOrchestrator fcmTokenOrchestrator;
+	private final FcmSenderOrchestrator fcmSenderOrchestrator;
 
 	public ArticleRedisBatchConsumerImpl(RedisTemplate<String, String> redisTemplate,
 		ReactiveRedisTemplate<String, String> reactiveRedisTemplate,
 		BatchConfig batchConfig,
 		OptionalObjectMapper optionalObjectMapper,
 		ArticleRepository articleRepository,
-		FcmTokenOrchestrator fcmTokenOrchestrator) {
+		FcmSenderOrchestrator fcmSenderOrchestrator) {
 		super(redisTemplate, reactiveRedisTemplate, batchConfig, optionalObjectMapper);
 		this.articleRepository = articleRepository;
-		this.fcmTokenOrchestrator = fcmTokenOrchestrator;
+		this.fcmSenderOrchestrator = fcmSenderOrchestrator;
 	}
 
 	@Override
@@ -181,7 +181,7 @@ public class ArticleRedisBatchConsumerImpl extends RedisBatchConsumer<Article>
 	private void sendFCM(List<ArticleEntityDto> saved) {
 		if (!saved.isEmpty()) {
 			for (ArticleEntityDto articleData : saved) {
-				fcmTokenOrchestrator.sendFcmWhenMailReceivedBatch(articleData.getToUserId(),
+				fcmSenderOrchestrator.sendFcmWhenMailReceivedBatch(articleData.getToUserId(),
 					articleData.getFromName(), articleData.getTitle());
 			}
 		}

--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
@@ -21,14 +21,15 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.stream.StreamReceiver;
 import org.springframework.stereotype.Component;
 
+import com.newzet.api.article.business.batch.ArticleBatchConsumer;
 import com.newzet.api.article.business.dto.ArticleEntityDto;
 import com.newzet.api.article.business.repository.ArticleRepository;
 import com.newzet.api.article.domain.Article;
 import com.newzet.api.article.repository.batch.dto.BatchProcessingResult;
 import com.newzet.api.article.repository.batch.dto.BatchSaveData;
-import com.newzet.api.common.batch.BatchConsumer;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
+import com.newzet.api.fcm.orchestrator.FcmTokenOrchestrator;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -38,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ArticleRedisBatchConsumerImpl implements BatchConsumer {
+public class ArticleRedisBatchConsumerImpl implements ArticleBatchConsumer {
 
 	private static final String ARTICLE_STREAM_KEY = "article:stream";
 	private static final String CONSUMER_GROUP = "article-processor-group";
@@ -51,9 +52,10 @@ public class ArticleRedisBatchConsumerImpl implements BatchConsumer {
 	private final ArticleRepository articleRepository;
 	private final BatchConfig batchConfig;
 	private final OptionalObjectMapper optionalObjectMapper;
+	private final FcmTokenOrchestrator fcmTokenOrchestrator;
+	private final AtomicBoolean isProcessing = new AtomicBoolean(false);
 	private ExecutorService executorService;
 	private ExecutorService ackExecutorService;
-	private final AtomicBoolean isProcessing = new AtomicBoolean(false);
 
 	@PostConstruct
 	public void init() {
@@ -280,12 +282,22 @@ public class ArticleRedisBatchConsumerImpl implements BatchConsumer {
 			try {
 				List<ArticleEntityDto> saved = articleRepository.saveAll(toSave);
 				result.setSuccessCount(saved.size());
+				sendFCM(saved); // fcm 메시지 전송 배치처리
 			} catch (Exception e) {
 				result.incrementFailCount(toSave.size());
 				log.error("SAVE FAILED for {} articles: {}", toSave.size(), e.getMessage(), e);
 			}
 		} else {
 			log.info("No new articles to save (all are duplicates or failed)");
+		}
+	}
+
+	private void sendFCM(List<ArticleEntityDto> saved) {
+		if (!saved.isEmpty()) {
+			for (ArticleEntityDto articleData : saved) {
+				fcmTokenOrchestrator.sendFcmWhenMailReceivedBatch(articleData.getToUserId(),
+					articleData.getFromName(), articleData.getTitle());
+			}
 		}
 	}
 
@@ -306,7 +318,7 @@ public class ArticleRedisBatchConsumerImpl implements BatchConsumer {
 
 	private void logBatchSummary(int totalArticles, BatchProcessingResult result, long duration) {
 		log.info(
-			"BATCH SUMMARY: total={}, success={}, duplicate={}, cacheHit={}, failed={}, elapsed={}ms",
+			"ARTICLE BATCH SUMMARY: total={}, success={}, duplicate={}, cacheHit={}, failed={}, elapsed={}ms",
 			totalArticles, result.getSuccessCount(), result.getDuplicateCount(),
 			result.getCacheHitCount(), result.getFailCount(), duration);
 	}

--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
@@ -5,20 +5,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.springframework.data.redis.connection.stream.Consumer;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.stream.StreamReceiver;
 import org.springframework.stereotype.Component;
 
 import com.newzet.api.article.business.batch.ArticleBatchConsumer;
@@ -27,19 +17,17 @@ import com.newzet.api.article.business.repository.ArticleRepository;
 import com.newzet.api.article.domain.Article;
 import com.newzet.api.article.repository.batch.dto.BatchProcessingResult;
 import com.newzet.api.article.repository.batch.dto.BatchSaveData;
+import com.newzet.api.common.batch.AbstractBatchConsumer;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.fcm.orchestrator.FcmTokenOrchestrator;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
-public class ArticleRedisBatchConsumerImpl implements ArticleBatchConsumer {
+public class ArticleRedisBatchConsumerImpl extends AbstractBatchConsumer<Article>
+	implements ArticleBatchConsumer {
 
 	private static final String ARTICLE_STREAM_KEY = "article:stream";
 	private static final String CONSUMER_GROUP = "article-processor-group";
@@ -47,151 +35,47 @@ public class ArticleRedisBatchConsumerImpl implements ArticleBatchConsumer {
 	private static final String ARTICLE_DUPLICATE_CACHE_PREFIX = "article:dup:";
 	private static final long DUPLICATE_CACHE_TTL_MINUTES = 10;
 
-	private final RedisTemplate<String, String> redisTemplate;
-	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
 	private final ArticleRepository articleRepository;
-	private final BatchConfig batchConfig;
-	private final OptionalObjectMapper optionalObjectMapper;
 	private final FcmTokenOrchestrator fcmTokenOrchestrator;
-	private final AtomicBoolean isProcessing = new AtomicBoolean(false);
-	private ExecutorService executorService;
-	private ExecutorService ackExecutorService;
 
-	@PostConstruct
-	public void init() {
-		try {
-			Boolean exists = redisTemplate.hasKey(ARTICLE_STREAM_KEY);
-			if (Boolean.FALSE.equals(exists)) {
-				Map<String, String> dummy = new HashMap<>();
-				dummy.put("init", "init");
-				redisTemplate.opsForStream().add(ARTICLE_STREAM_KEY, dummy);
-				log.info("Created new Redis Stream: {}", ARTICLE_STREAM_KEY);
-			}
-
-			try {
-				redisTemplate.opsForStream().createGroup(ARTICLE_STREAM_KEY, CONSUMER_GROUP);
-				log.info("Created new consumer group: {} for stream: {}", CONSUMER_GROUP,
-					ARTICLE_STREAM_KEY);
-			} catch (Exception e) {
-				log.debug("Consumer group may already exist: {}", e.getMessage());
-			}
-		} catch (Exception e) {
-			log.error("Failed to initialize Redis Stream: {}", e.getMessage(), e);
-		}
+	public ArticleRedisBatchConsumerImpl(RedisTemplate<String, String> redisTemplate,
+		ReactiveRedisTemplate<String, String> reactiveRedisTemplate,
+		BatchConfig batchConfig,
+		OptionalObjectMapper optionalObjectMapper,
+		ArticleRepository articleRepository,
+		FcmTokenOrchestrator fcmTokenOrchestrator) {
+		super(redisTemplate, reactiveRedisTemplate, batchConfig, optionalObjectMapper);
+		this.articleRepository = articleRepository;
+		this.fcmTokenOrchestrator = fcmTokenOrchestrator;
 	}
 
 	@Override
-	public Map<String, Object> getBatchStatus() {
-		Map<String, Object> status = new HashMap<>();
-		status.put("isProcessing", isProcessing.get());
-		status.put("batchSize", batchConfig.getBatchSize());
-
-		Long pendingCount = redisTemplate.opsForStream().size(ARTICLE_STREAM_KEY);
-		pendingCount = (pendingCount != null && pendingCount > 0) ? pendingCount - 1 : 0;
-		status.put("pendingMessages", pendingCount != null ? pendingCount : 0);
-
-		return status;
+	protected String getStreamKey() {
+		return ARTICLE_STREAM_KEY;
 	}
 
 	@Override
-	public void startProcessing() {
-		if (isProcessing.compareAndSet(false, true)) {
-			executorService = Executors.newSingleThreadExecutor();
-			ackExecutorService = Executors.newSingleThreadExecutor();
-			executorService.submit(this::processBatchesAsync);
-			log.info("Article batch processor started with configuration: size={}, timeout={}s",
-				batchConfig.getBatchSize(), batchConfig.getTimeoutSeconds());
-		}
+	protected String getConsumerGroup() {
+		return CONSUMER_GROUP;
 	}
 
 	@Override
-	public void stopProcessing() {
-		if (isProcessing.compareAndSet(true, false)) {
-			if (executorService != null) {
-				executorService.shutdownNow();
-				log.info("Article batch processor stopped");
-			}
-			if (ackExecutorService != null) {
-				ackExecutorService.shutdownNow();
-			}
-		}
+	protected String getConsumerName() {
+		return CONSUMER_NAME;
 	}
 
-	private void processBatchesAsync() {
-		log.info("Article batch processing thread initialized");
-
-		try {
-			StreamReceiver.StreamReceiverOptions<String, MapRecord<String, String, String>> options =
-				StreamReceiver.StreamReceiverOptions.builder()
-					.pollTimeout(Duration.ofSeconds(1))
-					.build();
-
-			StreamReceiver<String, MapRecord<String, String, String>> receiver =
-				StreamReceiver.create(reactiveRedisTemplate.getConnectionFactory(), options);
-
-			receiver.receive(
-					Consumer.from(CONSUMER_GROUP,
-						CONSUMER_NAME),
-					StreamOffset.create(ARTICLE_STREAM_KEY, ReadOffset.lastConsumed())
-				)
-				.bufferTimeout(batchConfig.getBatchSize(),
-					Duration.ofSeconds(batchConfig.getTimeoutSeconds()))
-				.doOnNext(records -> {
-					if (!records.isEmpty()) {
-						log.info("Processing article batch: count={}", records.size());
-						processBatchWithAck(records);
-					}
-				})
-				.doOnError(
-					error -> log.error("Stream processing error: {}", error.getMessage(), error))
-				.subscribe();
-
-			log.info("Subscribed to Redis Stream with consumer group: {}, consumer: {}",
-				CONSUMER_GROUP, CONSUMER_NAME);
-		} catch (Exception e) {
-			log.error("Failed to initialize batch processor: {}", e.getMessage(), e);
-			isProcessing.set(false);
-		}
+	@Override
+	protected String getProcessorTypeName() {
+		return "Article";
 	}
 
-	private void processBatchWithAck(List<MapRecord<String, String, String>> records) {
-		List<Article> articles = new ArrayList<>();
-
-		for (MapRecord<String, String, String> record : records) {
-			String data = record.getValue().get("data");
-			Optional<Article> article = optionalObjectMapper.deserialize(data, Article.class);
-			article.ifPresent(articles::add);
-		}
-
-		processBatchItems(articles);
-
-		CompletableFuture.runAsync(() -> {
-			List<String> ackedMessageIds = new ArrayList<>();
-
-			for (MapRecord<String, String, String> record : records) {
-				String messageId = record.getId().getValue();
-				try {
-					redisTemplate.opsForStream()
-						.acknowledge(ARTICLE_STREAM_KEY, CONSUMER_GROUP, messageId);
-					ackedMessageIds.add(messageId);
-				} catch (Exception e) {
-					log.warn("Ack failed for message {}, skipping for now: {}", messageId,
-						e.getMessage());
-				}
-			}
-
-			if (!ackedMessageIds.isEmpty()) {
-				try {
-					redisTemplate.opsForStream()
-						.delete(ARTICLE_STREAM_KEY, ackedMessageIds.toArray(new String[0]));
-				} catch (Exception e) {
-					log.error("Failed to delete acked messages: {}", e.getMessage(), e);
-				}
-			}
-		}, ackExecutorService);
+	@Override
+	protected Class<Article> getItemClass() {
+		return Article.class;
 	}
 
-	private void processBatchItems(List<Article> articles) {
+	@Override
+	protected void processBatchItems(List<Article> articles) {
 		long startTime = System.currentTimeMillis();
 		BatchProcessingResult result = new BatchProcessingResult();
 
@@ -228,7 +112,8 @@ public class ArticleRedisBatchConsumerImpl implements ArticleBatchConsumer {
 					entityDto.getToUserId()
 				);
 
-				keyToArticlesMap.computeIfAbsent(cacheKey, k -> new ArrayList<>()).add(entityDto);
+				keyToArticlesMap.computeIfAbsent(cacheKey, k -> new ArrayList<>())
+					.add(entityDto);
 			} catch (Exception e) {
 				result.incrementFailCount();
 				log.error("Failed to process article: {}, error: {}", article.getTitle(),
@@ -262,7 +147,8 @@ public class ArticleRedisBatchConsumerImpl implements ArticleBatchConsumer {
 			if (cachedValue != null) {
 				result.incrementDuplicateCount();
 				result.incrementCacheHitCount();
-				log.info("REDIS DUPLICATE: '{}' with key '{}', counters: duplicate={}, cacheHit={}",
+				log.info(
+					"REDIS DUPLICATE: '{}' with key '{}', counters: duplicate={}, cacheHit={}",
 					entityDto.getTitle(), cacheKey, result.getDuplicateCount(),
 					result.getCacheHitCount());
 			} else {
@@ -339,10 +225,5 @@ public class ArticleRedisBatchConsumerImpl implements ArticleBatchConsumer {
 			fromDomain + "_" +
 			userIdStr.substring(0, Math.min(8, userIdStr.length())) + "_" +
 			Math.abs(normalizedTitle.hashCode());
-	}
-
-	@PreDestroy
-	public void onShutdown() {
-		stopProcessing();
 	}
 }

--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
@@ -17,7 +17,7 @@ import com.newzet.api.article.business.repository.ArticleRepository;
 import com.newzet.api.article.domain.Article;
 import com.newzet.api.article.repository.batch.dto.BatchProcessingResult;
 import com.newzet.api.article.repository.batch.dto.BatchSaveData;
-import com.newzet.api.common.batch.AbstractBatchConsumer;
+import com.newzet.api.common.batch.RedisBatchConsumer;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.fcm.orchestrator.FcmTokenOrchestrator;
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-public class ArticleRedisBatchConsumerImpl extends AbstractBatchConsumer<Article>
+public class ArticleRedisBatchConsumerImpl extends RedisBatchConsumer<Article>
 	implements ArticleBatchConsumer {
 
 	private static final String ARTICLE_STREAM_KEY = "article:stream";

--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProducerImpl.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProducerImpl.java
@@ -5,14 +5,14 @@ import org.springframework.stereotype.Component;
 
 import com.newzet.api.article.business.batch.ArticleBatchProducer;
 import com.newzet.api.article.domain.Article;
-import com.newzet.api.common.batch.AbstractBatchProducer;
+import com.newzet.api.common.batch.RedisBatchProducer;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-public class ArticleRedisBatchProducerImpl extends AbstractBatchProducer<Article>
+public class ArticleRedisBatchProducerImpl extends RedisBatchProducer<Article>
 	implements ArticleBatchProducer {
 
 	private static final String ARTICLE_STREAM_KEY = "article:stream";

--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProducerImpl.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProducerImpl.java
@@ -6,8 +6,8 @@ import java.util.Map;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import com.newzet.api.article.business.batch.ArticleBatchProducer;
 import com.newzet.api.article.domain.Article;
-import com.newzet.api.common.batch.BatchProducer;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ import reactor.core.scheduler.Schedulers;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ArticleRedisBatchProducerImpl implements BatchProducer {
+public class ArticleRedisBatchProducerImpl implements ArticleBatchProducer {
 
 	private static final String ARTICLE_STREAM_KEY = "article:stream";
 	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;

--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProducerImpl.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProducerImpl.java
@@ -1,48 +1,40 @@
 package com.newzet.api.article.repository.batch;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import com.newzet.api.article.business.batch.ArticleBatchProducer;
 import com.newzet.api.article.domain.Article;
+import com.newzet.api.common.batch.AbstractBatchProducer;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.scheduler.Schedulers;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
-public class ArticleRedisBatchProducerImpl implements ArticleBatchProducer {
+public class ArticleRedisBatchProducerImpl extends AbstractBatchProducer<Article>
+	implements ArticleBatchProducer {
 
 	private static final String ARTICLE_STREAM_KEY = "article:stream";
-	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
-	private final OptionalObjectMapper optionalObjectMapper;
+
+	public ArticleRedisBatchProducerImpl(
+		ReactiveRedisTemplate<String, String> reactiveRedisTemplate,
+		OptionalObjectMapper optionalObjectMapper) {
+		super(reactiveRedisTemplate, optionalObjectMapper);
+	}
 
 	@Override
-	public void addToBatch(Article article) {
-		String jsonData = optionalObjectMapper.serialize(article);
+	protected String getStreamKey() {
+		return ARTICLE_STREAM_KEY;
+	}
 
-		Map<String, String> fields = new HashMap<>();
-		fields.put("data", jsonData);
+	@Override
+	protected String getItemTypeName() {
+		return "Article";
+	}
 
-		reactiveRedisTemplate.opsForStream()
-			.add(ARTICLE_STREAM_KEY, fields)
-			.subscribeOn(Schedulers.boundedElastic())
-			.doOnSuccess(recordId -> {
-				if (log.isDebugEnabled()) {
-					log.debug("Article added to batch queue: {}, recordId: {}",
-						article.getTitle(), recordId);
-				}
-			})
-			.doOnError(error ->
-				log.error("Failed to add article to stream: {}, error: {}",
-					article.getTitle(), error.getMessage(), error)
-			)
-			.subscribe();
+	@Override
+	protected String getItemIdentifier(Article article) {
+		return article.getTitle();
 	}
 }

--- a/src/main/java/com/newzet/api/common/batch/AbstractBatchConsumer.java
+++ b/src/main/java/com/newzet/api/common/batch/AbstractBatchConsumer.java
@@ -1,0 +1,218 @@
+package com.newzet.api.common.batch;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.stream.StreamReceiver;
+
+import com.newzet.api.common.batch.config.BatchConfig;
+import com.newzet.api.common.objectMapper.OptionalObjectMapper;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractBatchConsumer<T> implements BatchConsumer {
+
+	protected final RedisTemplate<String, String> redisTemplate;
+	protected final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+	protected final BatchConfig batchConfig;
+	protected final OptionalObjectMapper optionalObjectMapper;
+	protected final AtomicBoolean isProcessing = new AtomicBoolean(false);
+	protected ExecutorService executorService;
+	protected ExecutorService ackExecutorService;
+
+	@PostConstruct
+	public void init() {
+		try {
+			Boolean exists = redisTemplate.hasKey(getStreamKey());
+			if (Boolean.FALSE.equals(exists)) {
+				Map<String, String> dummy = new HashMap<>();
+				dummy.put("init", "init");
+				redisTemplate.opsForStream().add(getStreamKey(), dummy);
+				log.info("Created new Redis Stream: {}", getStreamKey());
+			}
+
+			try {
+				redisTemplate.opsForStream().createGroup(getStreamKey(), getConsumerGroup());
+				log.info("Created new consumer group: {} for stream: {}", getConsumerGroup(),
+					getStreamKey());
+			} catch (Exception e) {
+				log.debug("Consumer group may already exist: {}", e.getMessage());
+			}
+		} catch (Exception e) {
+			log.error("Failed to initialize Redis Stream: {}", e.getMessage(), e);
+		}
+	}
+
+	@Override
+	public Map<String, Object> getBatchStatus() {
+		Map<String, Object> status = new HashMap<>();
+		status.put("isProcessing", isProcessing.get());
+		status.put("batchSize", batchConfig.getBatchSize());
+
+		Long pendingCount = redisTemplate.opsForStream().size(getStreamKey());
+		pendingCount = (pendingCount != null && pendingCount > 0) ? pendingCount - 1 : 0;
+		status.put("pendingMessages", pendingCount != null ? pendingCount : 0);
+
+		return status;
+	}
+
+	@Override
+	public void startProcessing() {
+		if (isProcessing.compareAndSet(false, true)) {
+			executorService = Executors.newSingleThreadExecutor();
+			ackExecutorService = Executors.newSingleThreadExecutor();
+			executorService.submit(this::processBatchesAsync);
+			log.info("{} batch processor started with configuration: size={}, timeout={}s",
+				getProcessorTypeName(), batchConfig.getBatchSize(),
+				batchConfig.getTimeoutSeconds());
+		} else {
+			log.warn("{} batch processor is already running", getProcessorTypeName());
+		}
+	}
+
+	@Override
+	public void stopProcessing() {
+		if (isProcessing.compareAndSet(true, false)) {
+			if (executorService != null) {
+				executorService.shutdownNow();
+				log.info("{} batch processor stopped", getProcessorTypeName());
+			}
+			if (ackExecutorService != null) {
+				ackExecutorService.shutdownNow();
+			}
+		}
+	}
+
+	protected void processBatchesAsync() {
+		log.info("{} batch processing thread initialized", getProcessorTypeName());
+
+		try {
+			StreamReceiver.StreamReceiverOptions<String, MapRecord<String, String, String>> options =
+				StreamReceiver.StreamReceiverOptions.builder()
+					.pollTimeout(Duration.ofSeconds(1))
+					.build();
+
+			StreamReceiver<String, MapRecord<String, String, String>> receiver =
+				StreamReceiver.create(reactiveRedisTemplate.getConnectionFactory(), options);
+
+			receiver.receive(
+					Consumer.from(getConsumerGroup(), getConsumerName()),
+					StreamOffset.create(getStreamKey(), ReadOffset.lastConsumed())
+				)
+				.bufferTimeout(batchConfig.getBatchSize(),
+					Duration.ofSeconds(batchConfig.getTimeoutSeconds()))
+				.doOnNext(records -> {
+					if (!records.isEmpty()) {
+						log.info("Processing {} batch: count={}", getProcessorTypeName(),
+							records.size());
+						processBatchWithAck(records);
+					}
+				})
+				.doOnError(
+					error -> log.error("{} stream processing error: {}", getProcessorTypeName(),
+						error.getMessage(),
+						error))
+				.subscribe();
+
+			log.info("Subscribed to {} Redis Stream with consumer group: {}, consumer: {}",
+				getProcessorTypeName(), getConsumerGroup(), getConsumerName());
+		} catch (Exception e) {
+			log.error("Failed to initialize {} batch processor: {}", getProcessorTypeName(),
+				e.getMessage(), e);
+			isProcessing.set(false);
+		}
+	}
+
+	protected void processBatchWithAck(List<MapRecord<String, String, String>> records) {
+		List<T> items = new ArrayList<>();
+
+		for (MapRecord<String, String, String> record : records) {
+			try {
+				String data = record.getValue().get("data");
+				if (data != null) {
+					Optional<T> itemOpt = optionalObjectMapper.deserialize(data, getItemClass());
+					if (itemOpt.isPresent()) {
+						items.add(itemOpt.get());
+					} else {
+						log.warn("Failed to deserialize {} from record: {}", getProcessorTypeName(),
+							record.getId());
+					}
+				}
+			} catch (Exception e) {
+				log.error("Error processing {} record {}: {}", getProcessorTypeName(),
+					record.getId(), e.getMessage(), e);
+			}
+		}
+
+		processBatchItems(items);
+
+		CompletableFuture.runAsync(() -> {
+			List<String> ackedMessageIds = new ArrayList<>();
+
+			for (MapRecord<String, String, String> record : records) {
+				String messageId = record.getId().getValue();
+				try {
+					redisTemplate.opsForStream()
+						.acknowledge(getStreamKey(), getConsumerGroup(), messageId);
+					ackedMessageIds.add(messageId);
+				} catch (Exception e) {
+					log.warn("Ack failed for {} message {}, skipping for now: {}",
+						getProcessorTypeName(), messageId, e.getMessage());
+				}
+			}
+
+			if (!ackedMessageIds.isEmpty()) {
+				try {
+					redisTemplate.opsForStream()
+						.delete(getStreamKey(), ackedMessageIds.toArray(new String[0]));
+				} catch (Exception e) {
+					log.error("Failed to delete acked {} messages: {}", getProcessorTypeName(),
+						e.getMessage(), e);
+				}
+			}
+		}, ackExecutorService);
+	}
+
+	@PreDestroy
+	public void onShutdown() {
+		stopProcessing();
+		if (executorService != null && !executorService.isShutdown()) {
+			executorService.shutdown();
+		}
+		if (ackExecutorService != null && !ackExecutorService.isShutdown()) {
+			ackExecutorService.shutdown();
+		}
+		log.info("{} batch processor shutdown completed", getProcessorTypeName());
+	}
+
+	protected abstract String getStreamKey();
+
+	protected abstract String getConsumerGroup();
+
+	protected abstract String getConsumerName();
+
+	protected abstract String getProcessorTypeName();
+
+	protected abstract Class<T> getItemClass();
+
+	protected abstract void processBatchItems(List<T> items);
+}

--- a/src/main/java/com/newzet/api/common/batch/AbstractBatchProducer.java
+++ b/src/main/java/com/newzet/api/common/batch/AbstractBatchProducer.java
@@ -1,0 +1,49 @@
+package com.newzet.api.common.batch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+
+import com.newzet.api.common.objectMapper.OptionalObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractBatchProducer<T> implements BatchProducer<T> {
+
+	protected final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+	protected final OptionalObjectMapper optionalObjectMapper;
+
+	@Override
+	public void addToBatch(T item) {
+		String jsonData = optionalObjectMapper.serialize(item);
+
+		Map<String, String> fields = new HashMap<>();
+		fields.put("data", jsonData);
+
+		reactiveRedisTemplate.opsForStream()
+			.add(getStreamKey(), fields)
+			.subscribeOn(Schedulers.boundedElastic())
+			.doOnSuccess(recordId -> {
+				if (log.isDebugEnabled()) {
+					log.debug("{} added to batch queue: {}, recordId: {}",
+						getItemTypeName(), getItemIdentifier(item), recordId);
+				}
+			})
+			.doOnError(error ->
+				log.error("Failed to add {} to stream: {}, error: {}",
+					getItemTypeName(), getItemIdentifier(item), error.getMessage(), error)
+			)
+			.subscribe();
+	}
+
+	protected abstract String getStreamKey();
+
+	protected abstract String getItemTypeName();
+
+	protected abstract String getItemIdentifier(T item);
+}

--- a/src/main/java/com/newzet/api/common/batch/BatchProducer.java
+++ b/src/main/java/com/newzet/api/common/batch/BatchProducer.java
@@ -1,7 +1,5 @@
 package com.newzet.api.common.batch;
 
-import com.newzet.api.article.domain.Article;
-
-public interface BatchProducer {
-	void addToBatch(Article article);
+public interface BatchProducer<T> {
+	void addToBatch(T item);
 }

--- a/src/main/java/com/newzet/api/common/batch/RedisBatchConsumer.java
+++ b/src/main/java/com/newzet/api/common/batch/RedisBatchConsumer.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-public abstract class AbstractBatchConsumer<T> implements BatchConsumer {
+public abstract class RedisBatchConsumer<T> implements BatchConsumer {
 
 	protected final RedisTemplate<String, String> redisTemplate;
 	protected final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;

--- a/src/main/java/com/newzet/api/common/batch/RedisBatchProducer.java
+++ b/src/main/java/com/newzet/api/common/batch/RedisBatchProducer.java
@@ -13,7 +13,7 @@ import reactor.core.scheduler.Schedulers;
 
 @Slf4j
 @RequiredArgsConstructor
-public abstract class AbstractBatchProducer<T> implements BatchProducer<T> {
+public abstract class RedisBatchProducer<T> implements BatchProducer<T> {
 
 	protected final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
 	protected final OptionalObjectMapper optionalObjectMapper;

--- a/src/main/java/com/newzet/api/config/fcm/FirebaseConfig.java
+++ b/src/main/java/com/newzet/api/config/fcm/FirebaseConfig.java
@@ -1,11 +1,12 @@
 package com.newzet.api.config.fcm;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
@@ -15,15 +16,30 @@ import com.google.firebase.messaging.FirebaseMessaging;
 @Configuration
 public class FirebaseConfig {
 
+	@Value("${firebase.project-id}")
+	private String projectId;
+
+	@Value("${firebase.private-key-id}")
+	private String privateKeyId;
+
+	@Value("${firebase.private-key}")
+	private String privateKey;
+
+	@Value("${firebase.client-email}")
+	private String clientEmail;
+
+	@Value("${firebase.client-id}")
+	private String clientId;
+
 	@Bean
 	public FirebaseMessaging firebaseMessaging() throws IOException {
+		String serviceAccountJson = createServiceAccountJson();
 
-		ClassPathResource resource = new ClassPathResource("firebase-service-account.json");
-
-		InputStream serviceAccount = resource.getInputStream();
+		InputStream serviceAccount = new ByteArrayInputStream(serviceAccountJson.getBytes());
 
 		FirebaseOptions options = FirebaseOptions.builder()
 			.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+			.setProjectId(projectId)
 			.build();
 
 		if (FirebaseApp.getApps().isEmpty()) {
@@ -31,5 +47,30 @@ public class FirebaseConfig {
 		}
 
 		return FirebaseMessaging.getInstance();
+	}
+
+	private String createServiceAccountJson() {
+		return String.format("""
+				{
+				  "type": "service_account",
+				  "project_id": "%s",
+				  "private_key_id": "%s",
+				  "private_key": "%s",
+				  "client_email": "%s",
+				  "client_id": "%s",
+				  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+				  "token_uri": "https://oauth2.googleapis.com/token",
+				  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+				  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/%s",
+				  "universe_domain": "googleapis.com"
+				}
+				""",
+			projectId,
+			privateKeyId,
+			privateKey.replace("\\n", "\n"),
+			clientEmail,
+			clientId,
+			clientEmail.replace("@", "%40")
+		);
 	}
 }

--- a/src/main/java/com/newzet/api/config/fcm/FirebaseConfig.java
+++ b/src/main/java/com/newzet/api/config/fcm/FirebaseConfig.java
@@ -1,0 +1,35 @@
+package com.newzet.api.config.fcm;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+@Configuration
+public class FirebaseConfig {
+
+	@Bean
+	public FirebaseMessaging firebaseMessaging() throws IOException {
+
+		ClassPathResource resource = new ClassPathResource("firebase-service-account.json");
+
+		InputStream serviceAccount = resource.getInputStream();
+
+		FirebaseOptions options = FirebaseOptions.builder()
+			.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+			.build();
+
+		if (FirebaseApp.getApps().isEmpty()) {
+			FirebaseApp.initializeApp(options);
+		}
+
+		return FirebaseMessaging.getInstance();
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/business/batch/FcmBatchConsumer.java
+++ b/src/main/java/com/newzet/api/fcm/business/batch/FcmBatchConsumer.java
@@ -1,0 +1,6 @@
+package com.newzet.api.fcm.business.batch;
+
+import com.newzet.api.common.batch.BatchConsumer;
+
+public interface FcmBatchConsumer extends BatchConsumer {
+}

--- a/src/main/java/com/newzet/api/fcm/business/batch/FcmBatchProducer.java
+++ b/src/main/java/com/newzet/api/fcm/business/batch/FcmBatchProducer.java
@@ -1,0 +1,7 @@
+package com.newzet.api.fcm.business.batch;
+
+import com.newzet.api.fcm.domain.FcmNotification;
+import com.newzet.api.common.batch.BatchProducer;
+
+public interface FcmBatchProducer extends BatchProducer<FcmNotification> {
+}

--- a/src/main/java/com/newzet/api/fcm/business/repository/FcmTokenRepository.java
+++ b/src/main/java/com/newzet/api/fcm/business/repository/FcmTokenRepository.java
@@ -1,5 +1,6 @@
 package com.newzet.api.fcm.business.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +14,6 @@ public interface FcmTokenRepository {
 	FcmToken save(FcmToken fcmToken);
 
 	FcmToken findByUserIdAndValue(UUID userId, String value);
+
+	List<FcmToken> findAllByUserId(UUID userId);
 }

--- a/src/main/java/com/newzet/api/fcm/business/service/FcmSenderService.java
+++ b/src/main/java/com/newzet/api/fcm/business/service/FcmSenderService.java
@@ -1,0 +1,98 @@
+package com.newzet.api.fcm.business.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.newzet.api.fcm.business.batch.FcmBatchProducer;
+import com.newzet.api.fcm.business.repository.FcmTokenRepository;
+import com.newzet.api.fcm.domain.FcmNotification;
+import com.newzet.api.fcm.domain.FcmToken;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmSenderService {
+
+	private final FirebaseMessaging firebaseMessaging;
+	private final FcmTokenRepository fcmTokenRepository;
+	private final FcmBatchProducer batchProducer;
+
+	public void sendFcmWhenMailReceivedBatch(UUID userId, String fromName, String title) {
+		List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUserId(userId);
+		for (FcmToken fcmToken : fcmTokens) {
+			FcmNotification fcmNotification = FcmNotification.create(userId, fcmToken.value(),
+				fromName, title, null);
+			if (!fcmNotification.isValid()) {
+				log.warn("Invalid FCM notification, skipping: userId={}, token={}",
+					fcmNotification.getUserId(), fcmNotification.getToken());
+				return;
+			}
+			batchProducer.addToBatch(fcmNotification);
+		}
+	}
+
+	public void sendFcmNotBatch(UUID userId, String fromName, String title) {
+		List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUserId(userId);
+		for (FcmToken fcmToken : fcmTokens) {
+			FcmNotification fcmNotification = FcmNotification.create(userId, fcmToken.value(),
+				fromName, title, null);
+			if (!fcmNotification.isValid()) {
+				log.warn("Invalid FCM notification, skipping: userId={}, token={}",
+					fcmNotification.getUserId(), fcmNotification.getToken());
+				return;
+			}
+			send(fcmNotification);
+		}
+	}
+
+	public void send(FcmNotification fcmNotification) {
+		try {
+			Message message = buildFcmMessage(fcmNotification);
+			firebaseMessaging.send(message);
+		} catch (Exception e) {
+			handleSendFailure(fcmNotification, e);
+		}
+	}
+
+	private Message buildFcmMessage(FcmNotification fcmNotification) {
+		return Message.builder()
+			.setToken(fcmNotification.getToken())
+			.setNotification(Notification.builder()
+				.setTitle(fcmNotification.getTitle())
+				.setBody(fcmNotification.getBody())
+				.build())
+			.putData("data", fcmNotification.getData() != null ? fcmNotification.getData() : "")
+			.build();
+	}
+
+	private void handleSendFailure(FcmNotification fcmNotification, Exception e) {
+		if (isInvalidTokenError(e)) {
+			try {
+				FcmToken fcmToken = fcmTokenRepository.findByUserIdAndValue(
+					fcmNotification.getUserId(), fcmNotification.getToken());
+				fcmTokenRepository.deleteFcmToken(fcmToken);
+				log.info("Deleted invalid FCM token: userId={}, token={}",
+					fcmNotification.getUserId(), fcmNotification.getToken());
+			} catch (Exception deleteError) {
+				log.error("Failed to delete invalid FCM token: {}", deleteError.getMessage(),
+					deleteError);
+			}
+		}
+	}
+
+	private boolean isInvalidTokenError(Exception e) {
+		String errorMessage = e.getMessage().toLowerCase();
+		return errorMessage.contains("invalid registration token") ||
+			errorMessage.contains("registration token not registered") ||
+			errorMessage.contains("invalid argument") ||
+			errorMessage.contains("requested entity was not found");
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/business/service/FcmTokenService.java
+++ b/src/main/java/com/newzet/api/fcm/business/service/FcmTokenService.java
@@ -11,7 +11,9 @@ import com.newzet.api.fcm.domain.FcmNotification;
 import com.newzet.api.fcm.domain.FcmToken;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FcmTokenService {
@@ -36,6 +38,11 @@ public class FcmTokenService {
 		for (FcmToken fcmToken : fcmTokens) {
 			FcmNotification fcmNotification = FcmNotification.create(userId, fcmToken.value(),
 				fromName, title, null);
+			if (!fcmNotification.isValid()) {
+				log.warn("Invalid FCM notification, skipping: userId={}, token={}",
+					fcmNotification.getUserId(), fcmNotification.getToken());
+				return;
+			}
 			batchProducer.addToBatch(fcmNotification);
 		}
 	}

--- a/src/main/java/com/newzet/api/fcm/business/service/FcmTokenService.java
+++ b/src/main/java/com/newzet/api/fcm/business/service/FcmTokenService.java
@@ -1,13 +1,10 @@
 package com.newzet.api.fcm.business.service;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
-import com.newzet.api.fcm.business.batch.FcmBatchProducer;
 import com.newzet.api.fcm.business.repository.FcmTokenRepository;
-import com.newzet.api.fcm.domain.FcmNotification;
 import com.newzet.api.fcm.domain.FcmToken;
 
 import lombok.RequiredArgsConstructor;
@@ -19,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 public class FcmTokenService {
 
 	private final FcmTokenRepository fcmTokenRepository;
-	private final FcmBatchProducer batchProducer;
 
 	public FcmToken upsertFcmToken(UUID userId, String value) {
 		FcmToken fcmToken = fcmTokenRepository.findIfExistByValue(value)
@@ -31,19 +27,5 @@ public class FcmTokenService {
 	public void deleteFcmToken(UUID userId, String value) {
 		FcmToken fcmToken = fcmTokenRepository.findByUserIdAndValue(userId, value);
 		fcmTokenRepository.deleteFcmToken(fcmToken);
-	}
-
-	public void sendFcmWhenMailReceivedBatch(UUID userId, String fromName, String title) {
-		List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUserId(userId);
-		for (FcmToken fcmToken : fcmTokens) {
-			FcmNotification fcmNotification = FcmNotification.create(userId, fcmToken.value(),
-				fromName, title, null);
-			if (!fcmNotification.isValid()) {
-				log.warn("Invalid FCM notification, skipping: userId={}, token={}",
-					fcmNotification.getUserId(), fcmNotification.getToken());
-				return;
-			}
-			batchProducer.addToBatch(fcmNotification);
-		}
 	}
 }

--- a/src/main/java/com/newzet/api/fcm/business/service/FcmTokenService.java
+++ b/src/main/java/com/newzet/api/fcm/business/service/FcmTokenService.java
@@ -1,10 +1,13 @@
 package com.newzet.api.fcm.business.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
+import com.newzet.api.fcm.business.batch.FcmBatchProducer;
 import com.newzet.api.fcm.business.repository.FcmTokenRepository;
+import com.newzet.api.fcm.domain.FcmNotification;
 import com.newzet.api.fcm.domain.FcmToken;
 
 import lombok.RequiredArgsConstructor;
@@ -14,7 +17,8 @@ import lombok.RequiredArgsConstructor;
 public class FcmTokenService {
 
 	private final FcmTokenRepository fcmTokenRepository;
-    
+	private final FcmBatchProducer batchProducer;
+
 	public FcmToken upsertFcmToken(UUID userId, String value) {
 		FcmToken fcmToken = fcmTokenRepository.findIfExistByValue(value)
 			.map(existingToken -> existingToken.changeUserId(userId))
@@ -25,5 +29,14 @@ public class FcmTokenService {
 	public void deleteFcmToken(UUID userId, String value) {
 		FcmToken fcmToken = fcmTokenRepository.findByUserIdAndValue(userId, value);
 		fcmTokenRepository.deleteFcmToken(fcmToken);
+	}
+
+	public void sendFcmWhenMailReceivedBatch(UUID userId, String fromName, String title) {
+		List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUserId(userId);
+		for (FcmToken fcmToken : fcmTokens) {
+			FcmNotification fcmNotification = FcmNotification.create(userId, fcmToken.value(),
+				fromName, title, null);
+			batchProducer.addToBatch(fcmNotification);
+		}
 	}
 }

--- a/src/main/java/com/newzet/api/fcm/controller/FcmBatchController.java
+++ b/src/main/java/com/newzet/api/fcm/controller/FcmBatchController.java
@@ -1,0 +1,40 @@
+package com.newzet.api.fcm.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.newzet.api.fcm.business.batch.FcmBatchConsumer;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm/batch")
+@Tag(name = "FCM Batch", description = "[관리자용] FCM 배치 처리 관련 API")
+public class FcmBatchController {
+
+	private final FcmBatchConsumer fcmBatchConsumer;
+
+	@GetMapping("/status")
+	@Operation(summary = "[관리자용] FCM 배치 처리 상태 조회",
+		description = "현재 FCM 배치 처리 상태와 대기 중인 메시지 수를 조회합니다.")
+	public ResponseEntity<Map<String, Object>> getBatchStatus() {
+		return ResponseEntity.ok(fcmBatchConsumer.getBatchStatus());
+	}
+
+	@PostMapping("/restart")
+	@Operation(summary = "[관리자용] FCM 배치 처리 재시작",
+		description = "FCM 배치 처리를 중지하고 다시 시작합니다.")
+	public ResponseEntity<String> restartBatchProcessing() {
+		fcmBatchConsumer.stopProcessing();
+		fcmBatchConsumer.startProcessing();
+		return ResponseEntity.ok("FCM batch processing restarted");
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/newzet/api/fcm/domain/FcmNotification.java
@@ -1,0 +1,36 @@
+package com.newzet.api.fcm.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FcmNotification {
+	private UUID userId;
+	private String token;
+	private String title;
+	private String body;
+	private String data;
+	private LocalDateTime createdAt;
+
+	public static FcmNotification create(UUID userId, String token, String title, String body,
+		String data) {
+		return new FcmNotification(
+			userId,
+			token,
+			title,
+			body,
+			data,
+			LocalDateTime.now()
+		);
+	}
+
+	public boolean isValid() {
+		return token != null && !token.trim().isEmpty()
+			&& title != null && !title.trim().isEmpty();
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmBatchConfig.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmBatchConfig.java
@@ -1,0 +1,30 @@
+package com.newzet.api.fcm.jpa.batch;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.newzet.api.common.batch.config.BatchConfig;
+import com.newzet.api.fcm.business.batch.FcmBatchConsumer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class FcmBatchConfig {
+
+	private final FcmBatchConsumer fcmBatchConsumer;
+	private final BatchConfig batchConfig;
+
+	@Bean
+	public CommandLineRunner fcmBatchRunner() {
+		return args -> {
+			if (batchConfig.isAutoStart()) {
+				log.info("Auto-starting FCM batch processor");
+				fcmBatchConsumer.startProcessing();
+			}
+		};
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
@@ -85,6 +85,7 @@ public class FcmRedisBatchConsumerImpl extends RedisBatchConsumer<FcmNotificatio
 
 		try {
 			fcmSenderOrchestrator.send(fcmNotification);
+			result.incrementSuccessCount();
 		} catch (Exception e) {
 			result.incrementFailCount();
 		}

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
@@ -1,0 +1,277 @@
+package com.newzet.api.fcm.jpa.batch;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.stream.StreamReceiver;
+import org.springframework.stereotype.Component;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.newzet.api.common.batch.config.BatchConfig;
+import com.newzet.api.common.objectMapper.OptionalObjectMapper;
+import com.newzet.api.fcm.business.batch.FcmBatchConsumer;
+import com.newzet.api.fcm.domain.FcmNotification;
+import com.newzet.api.fcm.jpa.batch.dto.FcmBatchProcessingResult;
+import com.newzet.api.fcm.orchestrator.FcmTokenOrchestrator;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FcmRedisBatchConsumerImpl implements FcmBatchConsumer {
+
+	private static final String FCM_STREAM_KEY = "fcm:stream";
+	private static final String CONSUMER_GROUP = "fcm-processor-group";
+	private static final String CONSUMER_NAME = "fcm-processor";
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+	private final FcmTokenOrchestrator fcmTokenOrchestrator;
+	private final BatchConfig batchConfig;
+	private final OptionalObjectMapper optionalObjectMapper;
+	private final FirebaseMessaging firebaseMessaging;
+	private final AtomicBoolean isProcessing = new AtomicBoolean(false);
+	private ExecutorService executorService;
+	private ExecutorService ackExecutorService;
+
+	@PostConstruct
+	public void init() {
+		try {
+			Boolean exists = redisTemplate.hasKey(FCM_STREAM_KEY);
+			if (Boolean.FALSE.equals(exists)) {
+				Map<String, String> dummy = new HashMap<>();
+				dummy.put("init", "init");
+				redisTemplate.opsForStream().add(FCM_STREAM_KEY, dummy);
+				log.info("Created new Redis Stream: {}", FCM_STREAM_KEY);
+			}
+
+			try {
+				redisTemplate.opsForStream().createGroup(FCM_STREAM_KEY, CONSUMER_GROUP);
+				log.info("Created new consumer group: {} for stream: {}", CONSUMER_GROUP,
+					FCM_STREAM_KEY);
+			} catch (Exception e) {
+				log.debug("Consumer group may already exist: {}", e.getMessage());
+			}
+		} catch (Exception e) {
+			log.error("Failed to initialize Redis Stream: {}", e.getMessage(), e);
+		}
+	}
+
+	@Override
+	public Map<String, Object> getBatchStatus() {
+		Map<String, Object> status = new HashMap<>();
+		status.put("isProcessing", isProcessing.get());
+		status.put("batchSize", batchConfig.getBatchSize());
+
+		Long pendingCount = redisTemplate.opsForStream().size(FCM_STREAM_KEY);
+		pendingCount = (pendingCount != null && pendingCount > 0) ? pendingCount - 1 : 0;
+		status.put("pendingMessages", pendingCount != null ? pendingCount : 0);
+
+		return status;
+	}
+
+	@Override
+	public void startProcessing() {
+		if (isProcessing.compareAndSet(false, true)) {
+			executorService = Executors.newSingleThreadExecutor();
+			ackExecutorService = Executors.newSingleThreadExecutor();
+			executorService.submit(this::processBatchesAsync);
+			log.info("FCM batch processor started with configuration: size={}, timeout={}s",
+				batchConfig.getBatchSize(), batchConfig.getTimeoutSeconds());
+		}
+	}
+
+	@Override
+	public void stopProcessing() {
+		if (isProcessing.compareAndSet(true, false)) {
+			if (executorService != null) {
+				executorService.shutdownNow();
+				log.info("FCM batch processor stopped");
+			}
+			if (ackExecutorService != null) {
+				ackExecutorService.shutdownNow();
+			}
+		}
+	}
+
+	private void processBatchesAsync() {
+		log.info("FCM batch processing thread initialized");
+
+		try {
+			StreamReceiver.StreamReceiverOptions<String, MapRecord<String, String, String>> options =
+				StreamReceiver.StreamReceiverOptions.builder()
+					.pollTimeout(Duration.ofSeconds(1))
+					.build();
+
+			StreamReceiver<String, MapRecord<String, String, String>> receiver =
+				StreamReceiver.create(reactiveRedisTemplate.getConnectionFactory(), options);
+
+			receiver.receive(
+					Consumer.from(CONSUMER_GROUP, CONSUMER_NAME),
+					StreamOffset.create(FCM_STREAM_KEY, ReadOffset.lastConsumed())
+				)
+				.bufferTimeout(batchConfig.getBatchSize(),
+					Duration.ofSeconds(batchConfig.getTimeoutSeconds()))
+				.doOnNext(records -> {
+					if (!records.isEmpty()) {
+						log.info("Processing FCM batch: count={}", records.size());
+						processBatchWithAck(records);
+					}
+				})
+				.doOnError(
+					error -> log.error("FCM stream processing error: {}", error.getMessage(),
+						error))
+				.subscribe();
+
+			log.info("Subscribed to FCM Redis Stream with consumer group: {}, consumer: {}",
+				CONSUMER_GROUP, CONSUMER_NAME);
+		} catch (Exception e) {
+			log.error("Failed to initialize FCM batch processor: {}", e.getMessage(), e);
+			isProcessing.set(false);
+		}
+	}
+
+	private void processBatchWithAck(List<MapRecord<String, String, String>> records) {
+		List<FcmNotification> fcmNotifications = new ArrayList<>();
+
+		for (MapRecord<String, String, String> record : records) {
+			String data = record.getValue().get("data");
+			Optional<FcmNotification> fcmNotification = optionalObjectMapper.deserialize(data,
+				FcmNotification.class);
+			fcmNotification.ifPresent(fcmNotifications::add);
+		}
+
+		processBatchItems(fcmNotifications);
+
+		CompletableFuture.runAsync(() -> {
+			List<String> ackedMessageIds = new ArrayList<>();
+
+			for (MapRecord<String, String, String> record : records) {
+				String messageId = record.getId().getValue();
+				try {
+					redisTemplate.opsForStream()
+						.acknowledge(FCM_STREAM_KEY, CONSUMER_GROUP, messageId);
+					ackedMessageIds.add(messageId);
+				} catch (Exception e) {
+					log.warn("Ack failed for FCM message {}, skipping for now: {}", messageId,
+						e.getMessage());
+				}
+			}
+
+			if (!ackedMessageIds.isEmpty()) {
+				try {
+					redisTemplate.opsForStream()
+						.delete(FCM_STREAM_KEY, ackedMessageIds.toArray(new String[0]));
+				} catch (Exception e) {
+					log.error("Failed to delete acked FCM messages: {}", e.getMessage(), e);
+				}
+			}
+		}, ackExecutorService);
+	}
+
+	private void processBatchItems(List<FcmNotification> fcmNotifications) {
+		long startTime = System.currentTimeMillis();
+		FcmBatchProcessingResult result = new FcmBatchProcessingResult();
+
+		for (FcmNotification fcmNotification : fcmNotifications) {
+			processSingleNotification(fcmNotification, result);
+		}
+
+		long duration = System.currentTimeMillis() - startTime;
+		logBatchSummary(fcmNotifications.size(), result, duration);
+	}
+
+	private void processSingleNotification(FcmNotification fcmNotification,
+		FcmBatchProcessingResult result) {
+		if (!fcmNotification.isValid()) {
+			result.incrementInvalidTokenCount();
+			log.warn("Invalid FCM notification: userId={}, token={}",
+				fcmNotification.getUserId(), fcmNotification.getToken());
+			return;
+		}
+
+		try {
+			Message message = buildFcmMessage(fcmNotification);
+			String response = firebaseMessaging.send(message);
+			result.incrementSuccessCount();
+
+			if (log.isDebugEnabled()) {
+				log.debug("FCM sent successfully: userId={}, response={}",
+					fcmNotification.getUserId(), response);
+			}
+		} catch (Exception e) {
+			handleSendFailure(fcmNotification, result, e);
+		}
+	}
+
+	private Message buildFcmMessage(FcmNotification fcmNotification) {
+		return Message.builder()
+			.setToken(fcmNotification.getToken())
+			.setNotification(Notification.builder()
+				.setTitle(fcmNotification.getTitle())
+				.setBody(fcmNotification.getBody())
+				.build())
+			.putData("data", fcmNotification.getData() != null ? fcmNotification.getData() : "")
+			.build();
+	}
+
+	private void handleSendFailure(FcmNotification fcmNotification, FcmBatchProcessingResult result,
+		Exception e) {
+		result.incrementFailCount();
+		log.error("Failed to send FCM notification: userId={}, token={}, error={}",
+			fcmNotification.getUserId(), fcmNotification.getToken(), e.getMessage(), e);
+
+		if (isInvalidTokenError(e)) {
+			try {
+				fcmTokenOrchestrator.deleteFcmToken(fcmNotification.getUserId(),
+					fcmNotification.getToken());
+				log.info("Deleted invalid FCM token: userId={}, token={}",
+					fcmNotification.getUserId(), fcmNotification.getToken());
+			} catch (Exception deleteError) {
+				log.error("Failed to delete invalid FCM token: {}", deleteError.getMessage(),
+					deleteError);
+			}
+		}
+	}
+
+	private boolean isInvalidTokenError(Exception e) {
+		String errorMessage = e.getMessage().toLowerCase();
+		return errorMessage.contains("invalid registration token") ||
+			errorMessage.contains("registration token not registered") ||
+			errorMessage.contains("invalid argument") ||
+			errorMessage.contains("requested entity was not found");
+	}
+
+	private void logBatchSummary(int totalNotifications, FcmBatchProcessingResult result,
+		long duration) {
+		log.info(
+			"FCM BATCH SUMMARY: total={}, success={}, failed={}, invalidToken={}, elapsed={}ms",
+			totalNotifications, result.getSuccessCount(), result.getFailCount(),
+			result.getInvalidTokenCount(), duration);
+	}
+
+	@PreDestroy
+	public void onShutdown() {
+		stopProcessing();
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
@@ -6,17 +6,13 @@ import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import com.newzet.api.common.batch.RedisBatchConsumer;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.fcm.business.batch.FcmBatchConsumer;
-import com.newzet.api.fcm.business.repository.FcmTokenRepository;
 import com.newzet.api.fcm.domain.FcmNotification;
-import com.newzet.api.fcm.domain.FcmToken;
 import com.newzet.api.fcm.jpa.batch.dto.FcmBatchProcessingResult;
+import com.newzet.api.fcm.orchestrator.FcmSenderOrchestrator;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,18 +25,15 @@ public class FcmRedisBatchConsumerImpl extends RedisBatchConsumer<FcmNotificatio
 	private static final String CONSUMER_GROUP = "fcm-processor-group";
 	private static final String CONSUMER_NAME = "fcm-processor";
 
-	private final FcmTokenRepository fcmTokenRepository;
-	private final FirebaseMessaging firebaseMessaging;
+	private final FcmSenderOrchestrator fcmSenderOrchestrator;
 
 	public FcmRedisBatchConsumerImpl(RedisTemplate<String, String> redisTemplate,
 		ReactiveRedisTemplate<String, String> reactiveRedisTemplate,
 		BatchConfig batchConfig,
 		OptionalObjectMapper optionalObjectMapper,
-		FcmTokenRepository fcmTokenRepository,
-		FirebaseMessaging firebaseMessaging) {
+		FcmSenderOrchestrator fcmSenderOrchestrator) {
 		super(redisTemplate, reactiveRedisTemplate, batchConfig, optionalObjectMapper);
-		this.fcmTokenRepository = fcmTokenRepository;
-		this.firebaseMessaging = firebaseMessaging;
+		this.fcmSenderOrchestrator = fcmSenderOrchestrator;
 	}
 
 	@Override
@@ -91,56 +84,10 @@ public class FcmRedisBatchConsumerImpl extends RedisBatchConsumer<FcmNotificatio
 		}
 
 		try {
-			Message message = buildFcmMessage(fcmNotification);
-			String response = firebaseMessaging.send(message);
-			result.incrementSuccessCount();
-
-			if (log.isDebugEnabled()) {
-				log.debug("FCM sent successfully: userId={}, response={}",
-					fcmNotification.getUserId(), response);
-			}
+			fcmSenderOrchestrator.send(fcmNotification);
 		} catch (Exception e) {
-			handleSendFailure(fcmNotification, result, e);
+			result.incrementFailCount();
 		}
-	}
-
-	private Message buildFcmMessage(FcmNotification fcmNotification) {
-		return Message.builder()
-			.setToken(fcmNotification.getToken())
-			.setNotification(Notification.builder()
-				.setTitle(fcmNotification.getTitle())
-				.setBody(fcmNotification.getBody())
-				.build())
-			.putData("data", fcmNotification.getData() != null ? fcmNotification.getData() : "")
-			.build();
-	}
-
-	private void handleSendFailure(FcmNotification fcmNotification, FcmBatchProcessingResult result,
-		Exception e) {
-		result.incrementFailCount();
-		log.error("Failed to send FCM notification: userId={}, token={}, error={}",
-			fcmNotification.getUserId(), fcmNotification.getToken(), e.getMessage(), e);
-
-		if (isInvalidTokenError(e)) {
-			try {
-				FcmToken fcmToken = fcmTokenRepository.findByUserIdAndValue(
-					fcmNotification.getUserId(), fcmNotification.getToken());
-				fcmTokenRepository.deleteFcmToken(fcmToken);
-				log.info("Deleted invalid FCM token: userId={}, token={}",
-					fcmNotification.getUserId(), fcmNotification.getToken());
-			} catch (Exception deleteError) {
-				log.error("Failed to delete invalid FCM token: {}", deleteError.getMessage(),
-					deleteError);
-			}
-		}
-	}
-
-	private boolean isInvalidTokenError(Exception e) {
-		String errorMessage = e.getMessage().toLowerCase();
-		return errorMessage.contains("invalid registration token") ||
-			errorMessage.contains("registration token not registered") ||
-			errorMessage.contains("invalid argument") ||
-			errorMessage.contains("requested entity was not found");
 	}
 
 	private void logBatchSummary(int totalNotifications, FcmBatchProcessingResult result,

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
-import com.newzet.api.common.batch.AbstractBatchConsumer;
+import com.newzet.api.common.batch.RedisBatchConsumer;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.fcm.business.batch.FcmBatchConsumer;
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-public class FcmRedisBatchConsumerImpl extends AbstractBatchConsumer<FcmNotification>
+public class FcmRedisBatchConsumerImpl extends RedisBatchConsumer<FcmNotification>
 	implements FcmBatchConsumer {
 
 	private static final String FCM_STREAM_KEY = "fcm:stream";

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
@@ -26,9 +26,10 @@ import com.google.firebase.messaging.Notification;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.fcm.business.batch.FcmBatchConsumer;
+import com.newzet.api.fcm.business.repository.FcmTokenRepository;
 import com.newzet.api.fcm.domain.FcmNotification;
+import com.newzet.api.fcm.domain.FcmToken;
 import com.newzet.api.fcm.jpa.batch.dto.FcmBatchProcessingResult;
-import com.newzet.api.fcm.orchestrator.FcmTokenOrchestrator;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -46,7 +47,7 @@ public class FcmRedisBatchConsumerImpl implements FcmBatchConsumer {
 
 	private final RedisTemplate<String, String> redisTemplate;
 	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
-	private final FcmTokenOrchestrator fcmTokenOrchestrator;
+	private final FcmTokenRepository fcmTokenRepository;
 	private final BatchConfig batchConfig;
 	private final OptionalObjectMapper optionalObjectMapper;
 	private final FirebaseMessaging firebaseMessaging;
@@ -243,8 +244,9 @@ public class FcmRedisBatchConsumerImpl implements FcmBatchConsumer {
 
 		if (isInvalidTokenError(e)) {
 			try {
-				fcmTokenOrchestrator.deleteFcmToken(fcmNotification.getUserId(),
-					fcmNotification.getToken());
+				FcmToken fcmToken = fcmTokenRepository.findByUserIdAndValue(
+					fcmNotification.getUserId(), fcmNotification.getToken());
+				fcmTokenRepository.deleteFcmToken(fcmToken);
 				log.info("Deleted invalid FCM token: userId={}, token={}",
 					fcmNotification.getUserId(), fcmNotification.getToken());
 			} catch (Exception deleteError) {

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchConsumerImpl.java
@@ -1,28 +1,15 @@
 package com.newzet.api.fcm.jpa.batch;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.springframework.data.redis.connection.stream.Consumer;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.stream.StreamReceiver;
 import org.springframework.stereotype.Component;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import com.newzet.api.common.batch.AbstractBatchConsumer;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.fcm.business.batch.FcmBatchConsumer;
@@ -31,166 +18,58 @@ import com.newzet.api.fcm.domain.FcmNotification;
 import com.newzet.api.fcm.domain.FcmToken;
 import com.newzet.api.fcm.jpa.batch.dto.FcmBatchProcessingResult;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
-public class FcmRedisBatchConsumerImpl implements FcmBatchConsumer {
+public class FcmRedisBatchConsumerImpl extends AbstractBatchConsumer<FcmNotification>
+	implements FcmBatchConsumer {
 
 	private static final String FCM_STREAM_KEY = "fcm:stream";
 	private static final String CONSUMER_GROUP = "fcm-processor-group";
 	private static final String CONSUMER_NAME = "fcm-processor";
 
-	private final RedisTemplate<String, String> redisTemplate;
-	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
 	private final FcmTokenRepository fcmTokenRepository;
-	private final BatchConfig batchConfig;
-	private final OptionalObjectMapper optionalObjectMapper;
 	private final FirebaseMessaging firebaseMessaging;
-	private final AtomicBoolean isProcessing = new AtomicBoolean(false);
-	private ExecutorService executorService;
-	private ExecutorService ackExecutorService;
 
-	@PostConstruct
-	public void init() {
-		try {
-			Boolean exists = redisTemplate.hasKey(FCM_STREAM_KEY);
-			if (Boolean.FALSE.equals(exists)) {
-				Map<String, String> dummy = new HashMap<>();
-				dummy.put("init", "init");
-				redisTemplate.opsForStream().add(FCM_STREAM_KEY, dummy);
-				log.info("Created new Redis Stream: {}", FCM_STREAM_KEY);
-			}
-
-			try {
-				redisTemplate.opsForStream().createGroup(FCM_STREAM_KEY, CONSUMER_GROUP);
-				log.info("Created new consumer group: {} for stream: {}", CONSUMER_GROUP,
-					FCM_STREAM_KEY);
-			} catch (Exception e) {
-				log.debug("Consumer group may already exist: {}", e.getMessage());
-			}
-		} catch (Exception e) {
-			log.error("Failed to initialize Redis Stream: {}", e.getMessage(), e);
-		}
+	public FcmRedisBatchConsumerImpl(RedisTemplate<String, String> redisTemplate,
+		ReactiveRedisTemplate<String, String> reactiveRedisTemplate,
+		BatchConfig batchConfig,
+		OptionalObjectMapper optionalObjectMapper,
+		FcmTokenRepository fcmTokenRepository,
+		FirebaseMessaging firebaseMessaging) {
+		super(redisTemplate, reactiveRedisTemplate, batchConfig, optionalObjectMapper);
+		this.fcmTokenRepository = fcmTokenRepository;
+		this.firebaseMessaging = firebaseMessaging;
 	}
 
 	@Override
-	public Map<String, Object> getBatchStatus() {
-		Map<String, Object> status = new HashMap<>();
-		status.put("isProcessing", isProcessing.get());
-		status.put("batchSize", batchConfig.getBatchSize());
-
-		Long pendingCount = redisTemplate.opsForStream().size(FCM_STREAM_KEY);
-		pendingCount = (pendingCount != null && pendingCount > 0) ? pendingCount - 1 : 0;
-		status.put("pendingMessages", pendingCount != null ? pendingCount : 0);
-
-		return status;
+	protected String getStreamKey() {
+		return FCM_STREAM_KEY;
 	}
 
 	@Override
-	public void startProcessing() {
-		if (isProcessing.compareAndSet(false, true)) {
-			executorService = Executors.newSingleThreadExecutor();
-			ackExecutorService = Executors.newSingleThreadExecutor();
-			executorService.submit(this::processBatchesAsync);
-			log.info("FCM batch processor started with configuration: size={}, timeout={}s",
-				batchConfig.getBatchSize(), batchConfig.getTimeoutSeconds());
-		}
+	protected String getConsumerGroup() {
+		return CONSUMER_GROUP;
 	}
 
 	@Override
-	public void stopProcessing() {
-		if (isProcessing.compareAndSet(true, false)) {
-			if (executorService != null) {
-				executorService.shutdownNow();
-				log.info("FCM batch processor stopped");
-			}
-			if (ackExecutorService != null) {
-				ackExecutorService.shutdownNow();
-			}
-		}
+	protected String getConsumerName() {
+		return CONSUMER_NAME;
 	}
 
-	private void processBatchesAsync() {
-		log.info("FCM batch processing thread initialized");
-
-		try {
-			StreamReceiver.StreamReceiverOptions<String, MapRecord<String, String, String>> options =
-				StreamReceiver.StreamReceiverOptions.builder()
-					.pollTimeout(Duration.ofSeconds(1))
-					.build();
-
-			StreamReceiver<String, MapRecord<String, String, String>> receiver =
-				StreamReceiver.create(reactiveRedisTemplate.getConnectionFactory(), options);
-
-			receiver.receive(
-					Consumer.from(CONSUMER_GROUP, CONSUMER_NAME),
-					StreamOffset.create(FCM_STREAM_KEY, ReadOffset.lastConsumed())
-				)
-				.bufferTimeout(batchConfig.getBatchSize(),
-					Duration.ofSeconds(batchConfig.getTimeoutSeconds()))
-				.doOnNext(records -> {
-					if (!records.isEmpty()) {
-						log.info("Processing FCM batch: count={}", records.size());
-						processBatchWithAck(records);
-					}
-				})
-				.doOnError(
-					error -> log.error("FCM stream processing error: {}", error.getMessage(),
-						error))
-				.subscribe();
-
-			log.info("Subscribed to FCM Redis Stream with consumer group: {}, consumer: {}",
-				CONSUMER_GROUP, CONSUMER_NAME);
-		} catch (Exception e) {
-			log.error("Failed to initialize FCM batch processor: {}", e.getMessage(), e);
-			isProcessing.set(false);
-		}
+	@Override
+	protected String getProcessorTypeName() {
+		return "FCM";
 	}
 
-	private void processBatchWithAck(List<MapRecord<String, String, String>> records) {
-		List<FcmNotification> fcmNotifications = new ArrayList<>();
-
-		for (MapRecord<String, String, String> record : records) {
-			String data = record.getValue().get("data");
-			Optional<FcmNotification> fcmNotification = optionalObjectMapper.deserialize(data,
-				FcmNotification.class);
-			fcmNotification.ifPresent(fcmNotifications::add);
-		}
-
-		processBatchItems(fcmNotifications);
-
-		CompletableFuture.runAsync(() -> {
-			List<String> ackedMessageIds = new ArrayList<>();
-
-			for (MapRecord<String, String, String> record : records) {
-				String messageId = record.getId().getValue();
-				try {
-					redisTemplate.opsForStream()
-						.acknowledge(FCM_STREAM_KEY, CONSUMER_GROUP, messageId);
-					ackedMessageIds.add(messageId);
-				} catch (Exception e) {
-					log.warn("Ack failed for FCM message {}, skipping for now: {}", messageId,
-						e.getMessage());
-				}
-			}
-
-			if (!ackedMessageIds.isEmpty()) {
-				try {
-					redisTemplate.opsForStream()
-						.delete(FCM_STREAM_KEY, ackedMessageIds.toArray(new String[0]));
-				} catch (Exception e) {
-					log.error("Failed to delete acked FCM messages: {}", e.getMessage(), e);
-				}
-			}
-		}, ackExecutorService);
+	@Override
+	protected Class<FcmNotification> getItemClass() {
+		return FcmNotification.class;
 	}
 
-	private void processBatchItems(List<FcmNotification> fcmNotifications) {
+	@Override
+	protected void processBatchItems(List<FcmNotification> fcmNotifications) {
 		long startTime = System.currentTimeMillis();
 		FcmBatchProcessingResult result = new FcmBatchProcessingResult();
 
@@ -270,10 +149,5 @@ public class FcmRedisBatchConsumerImpl implements FcmBatchConsumer {
 			"FCM BATCH SUMMARY: total={}, success={}, failed={}, invalidToken={}, elapsed={}ms",
 			totalNotifications, result.getSuccessCount(), result.getFailCount(),
 			result.getInvalidTokenCount(), duration);
-	}
-
-	@PreDestroy
-	public void onShutdown() {
-		stopProcessing();
 	}
 }

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
@@ -25,12 +25,6 @@ public class FcmRedisBatchProducerImpl implements FcmBatchProducer {
 
 	@Override
 	public void addToBatch(FcmNotification fcmNotification) {
-		if (!fcmNotification.isValid()) {
-			log.warn("Invalid FCM notification, skipping: userId={}, token={}",
-				fcmNotification.getUserId(), fcmNotification.getToken());
-			return;
-		}
-
 		String jsonData = optionalObjectMapper.serialize(fcmNotification);
 
 		Map<String, String> fields = new HashMap<>();

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
@@ -3,7 +3,7 @@ package com.newzet.api.fcm.jpa.batch;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
 
-import com.newzet.api.common.batch.AbstractBatchProducer;
+import com.newzet.api.common.batch.RedisBatchProducer;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.fcm.business.batch.FcmBatchProducer;
 import com.newzet.api.fcm.domain.FcmNotification;
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-public class FcmRedisBatchProducerImpl extends AbstractBatchProducer<FcmNotification>
+public class FcmRedisBatchProducerImpl extends RedisBatchProducer<FcmNotification>
 	implements FcmBatchProducer {
 
 	private static final String FCM_STREAM_KEY = "fcm:stream";

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
@@ -1,0 +1,56 @@
+package com.newzet.api.fcm.jpa.batch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.newzet.api.common.objectMapper.OptionalObjectMapper;
+import com.newzet.api.fcm.business.batch.FcmBatchProducer;
+import com.newzet.api.fcm.domain.FcmNotification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FcmRedisBatchProducerImpl implements FcmBatchProducer {
+
+	private static final String FCM_STREAM_KEY = "fcm:stream";
+	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+	private final OptionalObjectMapper optionalObjectMapper;
+
+	@Override
+	public void addToBatch(FcmNotification fcmNotification) {
+		if (!fcmNotification.isValid()) {
+			log.warn("Invalid FCM notification, skipping: userId={}, token={}",
+				fcmNotification.getUserId(), fcmNotification.getToken());
+			return;
+		}
+
+		String jsonData = optionalObjectMapper.serialize(fcmNotification);
+
+		Map<String, String> fields = new HashMap<>();
+		fields.put("data", jsonData);
+
+		reactiveRedisTemplate.opsForStream()
+			.add(FCM_STREAM_KEY, fields)
+			.subscribeOn(Schedulers.boundedElastic())
+			.doOnSuccess(recordId -> {
+				if (log.isDebugEnabled()) {
+					log.debug(
+						"FCM notification added to batch queue: userId={}, title={}, recordId={}",
+						fcmNotification.getUserId(), fcmNotification.getTitle(), recordId);
+				}
+			})
+			.doOnError(error ->
+				log.error("Failed to add FCM notification to stream: userId={}, title={}, error={}",
+					fcmNotification.getUserId(), fcmNotification.getTitle(), error.getMessage(),
+					error)
+			)
+			.subscribe();
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
@@ -1,50 +1,40 @@
 package com.newzet.api.fcm.jpa.batch;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import com.newzet.api.common.batch.AbstractBatchProducer;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.fcm.business.batch.FcmBatchProducer;
 import com.newzet.api.fcm.domain.FcmNotification;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.scheduler.Schedulers;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
-public class FcmRedisBatchProducerImpl implements FcmBatchProducer {
+public class FcmRedisBatchProducerImpl extends AbstractBatchProducer<FcmNotification>
+	implements FcmBatchProducer {
 
 	private static final String FCM_STREAM_KEY = "fcm:stream";
-	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
-	private final OptionalObjectMapper optionalObjectMapper;
+
+	public FcmRedisBatchProducerImpl(ReactiveRedisTemplate<String, String> reactiveRedisTemplate,
+		OptionalObjectMapper optionalObjectMapper) {
+		super(reactiveRedisTemplate, optionalObjectMapper);
+	}
 
 	@Override
-	public void addToBatch(FcmNotification fcmNotification) {
-		String jsonData = optionalObjectMapper.serialize(fcmNotification);
+	protected String getStreamKey() {
+		return FCM_STREAM_KEY;
+	}
 
-		Map<String, String> fields = new HashMap<>();
-		fields.put("data", jsonData);
+	@Override
+	protected String getItemTypeName() {
+		return "FCM notification";
+	}
 
-		reactiveRedisTemplate.opsForStream()
-			.add(FCM_STREAM_KEY, fields)
-			.subscribeOn(Schedulers.boundedElastic())
-			.doOnSuccess(recordId -> {
-				if (log.isDebugEnabled()) {
-					log.debug(
-						"FCM notification added to batch queue: userId={}, title={}, recordId={}",
-						fcmNotification.getUserId(), fcmNotification.getTitle(), recordId);
-				}
-			})
-			.doOnError(error ->
-				log.error("Failed to add FCM notification to stream: userId={}, title={}, error={}",
-					fcmNotification.getUserId(), fcmNotification.getTitle(), error.getMessage(),
-					error)
-			)
-			.subscribe();
+	@Override
+	protected String getItemIdentifier(FcmNotification fcmNotification) {
+		return String.format("userId=%s, title=%s", fcmNotification.getUserId(),
+			fcmNotification.getTitle());
 	}
 }

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/dto/FcmBatchProcessingResult.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/dto/FcmBatchProcessingResult.java
@@ -1,0 +1,26 @@
+package com.newzet.api.fcm.jpa.batch.dto;
+
+import lombok.Data;
+
+@Data
+public class FcmBatchProcessingResult {
+	private int successCount;
+	private int failCount;
+	private int invalidTokenCount;
+
+	public void incrementSuccessCount() {
+		this.successCount++;
+	}
+
+	public void incrementFailCount() {
+		this.failCount++;
+	}
+
+	public void incrementInvalidTokenCount() {
+		this.invalidTokenCount++;
+	}
+
+	public void addToFailCount(int count) {
+		this.failCount += count;
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/dto/FcmBatchProcessingResult.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/dto/FcmBatchProcessingResult.java
@@ -19,8 +19,4 @@ public class FcmBatchProcessingResult {
 	public void incrementInvalidTokenCount() {
 		this.invalidTokenCount++;
 	}
-
-	public void addToFailCount(int count) {
-		this.failCount += count;
-	}
 }

--- a/src/main/java/com/newzet/api/fcm/jpa/repository/FcmTokenJpaRepository.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/repository/FcmTokenJpaRepository.java
@@ -1,5 +1,6 @@
 package com.newzet.api.fcm.jpa.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +12,6 @@ public interface FcmTokenJpaRepository extends JpaRepository<FcmTokenEntity, UUI
 	Optional<FcmTokenEntity> findByFcmToken(String value);
 
 	Optional<FcmTokenEntity> findByUserIdAndFcmToken(UUID userId, String fcmToken);
+
+	List<FcmTokenEntity> findAllByUserId(UUID userId);
 }

--- a/src/main/java/com/newzet/api/fcm/jpa/repository/FcmTokenRepositoryImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/repository/FcmTokenRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.newzet.api.fcm.jpa.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -35,7 +36,8 @@ public class FcmTokenRepositoryImpl implements FcmTokenRepository {
 
 	@Override
 	public FcmToken save(FcmToken fcmToken) {
-		FcmTokenEntity savedFcmTokenEntity = fcmTokenJpaRepository.save(FcmTokenMapper.toEntity(fcmToken));
+		FcmTokenEntity savedFcmTokenEntity = fcmTokenJpaRepository.save(
+			FcmTokenMapper.toEntity(fcmToken));
 		return FcmTokenMapper.toDomain(savedFcmTokenEntity);
 	}
 
@@ -44,6 +46,14 @@ public class FcmTokenRepositoryImpl implements FcmTokenRepository {
 		return fcmTokenJpaRepository.findByUserIdAndFcmToken(userId, value)
 			.map(FcmTokenMapper::toDomain)
 			.orElseThrow(
-				() -> new NoFcmTokenException("FCM Token이 존재하지 않습니다. id = " + userId + ", value = " + value));
+				() -> new NoFcmTokenException(
+					"FCM Token이 존재하지 않습니다. id = " + userId + ", value = " + value));
+	}
+
+	@Override
+	public List<FcmToken> findAllByUserId(UUID userId) {
+		return fcmTokenJpaRepository.findAllByUserId(userId)
+			.stream().map(FcmTokenMapper::toDomain)
+			.toList();
 	}
 }

--- a/src/main/java/com/newzet/api/fcm/orchestrator/FcmSenderOrchestrator.java
+++ b/src/main/java/com/newzet/api/fcm/orchestrator/FcmSenderOrchestrator.java
@@ -1,0 +1,31 @@
+package com.newzet.api.fcm.orchestrator;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.newzet.api.fcm.business.service.FcmSenderService;
+import com.newzet.api.fcm.domain.FcmNotification;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FcmSenderOrchestrator {
+
+	private final FcmSenderService fcmSenderService;
+
+	public void sendFcmWhenMailReceivedBatch(UUID userId, String fromName, String title) {
+		fcmSenderService.sendFcmWhenMailReceivedBatch(userId, fromName, title);
+	}
+
+	public void sendFcmNotBatch(UUID userId, String fromName, String title) {
+		fcmSenderService.sendFcmNotBatch(userId, fromName, title);
+	}
+
+	public void send(FcmNotification fcmNotification) { // Consumer 이외에서 사용 금지
+		fcmSenderService.send(fcmNotification);
+	}
+}

--- a/src/main/java/com/newzet/api/fcm/orchestrator/FcmTokenOrchestrator.java
+++ b/src/main/java/com/newzet/api/fcm/orchestrator/FcmTokenOrchestrator.java
@@ -23,4 +23,8 @@ public class FcmTokenOrchestrator {
 	public void deleteFcmToken(UUID userId, String value) {
 		fcmTokenService.deleteFcmToken(userId, value);
 	}
+
+	public void sendFcmWhenMailReceivedBatch(UUID userId, String fromName, String title) {
+		fcmTokenService.sendFcmWhenMailReceivedBatch(userId, fromName, title);
+	}
 }

--- a/src/main/java/com/newzet/api/fcm/orchestrator/FcmTokenOrchestrator.java
+++ b/src/main/java/com/newzet/api/fcm/orchestrator/FcmTokenOrchestrator.java
@@ -23,8 +23,4 @@ public class FcmTokenOrchestrator {
 	public void deleteFcmToken(UUID userId, String value) {
 		fcmTokenService.deleteFcmToken(userId, value);
 	}
-
-	public void sendFcmWhenMailReceivedBatch(UUID userId, String fromName, String title) {
-		fcmTokenService.sendFcmWhenMailReceivedBatch(userId, fromName, title);
-	}
 }

--- a/src/main/java/com/newzet/api/mail/business/MailServiceFacade.java
+++ b/src/main/java/com/newzet/api/mail/business/MailServiceFacade.java
@@ -26,7 +26,5 @@ public class MailServiceFacade {
 		subscriptionService.addSubscriptionIfUnsubscribed(userId, fromName, fromDomain,
 			mailingList);
 		articleService.saveArticleBatch(userId, fromName, fromDomain, mailingList, htmlLink, title);
-
-		//TODO: 아티클 저장 후 배치처리 된 애들에 대해서 별도로 event 형식으로 fcm noti 보내는거 추가 (여기 말고)
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,3 +51,10 @@ server:
   tomcat:
     mbeanregistry:
       enabled: true
+
+firebase:
+  project-id: ${FIREBASE_PROJECT_ID}
+  private-key-id: ${FIREBASE_PRIVATE_KEY_ID}
+  private-key: ${FIREBASE_PRIVATE_KEY}
+  client-email: ${FIREBASE_CLIENT_EMAIL}
+  client-id: ${FIREBASE_CLIENT_ID}

--- a/src/test/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProcessorIntegrationTest.java
+++ b/src/test/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProcessorIntegrationTest.java
@@ -38,7 +38,7 @@ import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.config.JwtTestConfig;
 import com.newzet.api.config.PostgresTestContainerConfig;
 import com.newzet.api.config.RedisTestContainerConfig;
-import com.newzet.api.fcm.orchestrator.FcmTokenOrchestrator;
+import com.newzet.api.fcm.orchestrator.FcmSenderOrchestrator;
 
 @ExtendWith({RedisTestContainerConfig.class, PostgresTestContainerConfig.class,
 	JwtTestConfig.class})
@@ -59,7 +59,7 @@ class ArticleRedisBatchProcessorIntegrationTest {
 	private OptionalObjectMapper optionalObjectMapper;
 
 	@Autowired
-	private FcmTokenOrchestrator fcmTokenOrchestrator;
+	private FcmSenderOrchestrator fcmSenderOrchestrator;
 
 	@MockitoBean
 	private ArticleRepository articleRepository;
@@ -95,7 +95,7 @@ class ArticleRedisBatchProcessorIntegrationTest {
 			mockBatchConfig,
 			optionalObjectMapper,
 			articleRepository,
-			fcmTokenOrchestrator
+			fcmSenderOrchestrator
 		);
 
 		initializeStream();
@@ -242,7 +242,7 @@ class ArticleRedisBatchProcessorIntegrationTest {
 			mockBatchConfig,
 			optionalObjectMapper,
 			articleRepository,
-			fcmTokenOrchestrator
+			fcmSenderOrchestrator
 		);
 
 		consumerWithMockRedis.init();
@@ -263,7 +263,7 @@ class ArticleRedisBatchProcessorIntegrationTest {
 			mock(BatchConfig.class),
 			optionalObjectMapper,
 			mock(ArticleRepository.class),
-			fcmTokenOrchestrator
+			fcmSenderOrchestrator
 		);
 
 		Map<String, Object> status = consumerWithMockRedis.getBatchStatus();

--- a/src/test/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProcessorIntegrationTest.java
+++ b/src/test/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProcessorIntegrationTest.java
@@ -35,13 +35,14 @@ import com.newzet.api.common.batch.BatchConsumer;
 import com.newzet.api.common.batch.BatchProducer;
 import com.newzet.api.common.batch.config.BatchConfig;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
+import com.newzet.api.config.FirebaseTestConfig;
 import com.newzet.api.config.JwtTestConfig;
 import com.newzet.api.config.PostgresTestContainerConfig;
 import com.newzet.api.config.RedisTestContainerConfig;
 import com.newzet.api.fcm.orchestrator.FcmSenderOrchestrator;
 
 @ExtendWith({RedisTestContainerConfig.class, PostgresTestContainerConfig.class,
-	JwtTestConfig.class})
+	JwtTestConfig.class, FirebaseTestConfig.class})
 @SpringBootTest
 @ComponentScan(basePackages = {"com.newzet.api.article", "com.newzet.api.common"})
 class ArticleRedisBatchProcessorIntegrationTest {

--- a/src/test/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProcessorIntegrationTest.java
+++ b/src/test/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProcessorIntegrationTest.java
@@ -38,6 +38,7 @@ import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 import com.newzet.api.config.JwtTestConfig;
 import com.newzet.api.config.PostgresTestContainerConfig;
 import com.newzet.api.config.RedisTestContainerConfig;
+import com.newzet.api.fcm.orchestrator.FcmTokenOrchestrator;
 
 @ExtendWith({RedisTestContainerConfig.class, PostgresTestContainerConfig.class,
 	JwtTestConfig.class})
@@ -56,6 +57,9 @@ class ArticleRedisBatchProcessorIntegrationTest {
 
 	@Autowired
 	private OptionalObjectMapper optionalObjectMapper;
+
+	@Autowired
+	private FcmTokenOrchestrator fcmTokenOrchestrator;
 
 	@MockitoBean
 	private ArticleRepository articleRepository;
@@ -90,7 +94,8 @@ class ArticleRedisBatchProcessorIntegrationTest {
 			reactiveRedisTemplate,
 			articleRepository,
 			mockBatchConfig,
-			optionalObjectMapper
+			optionalObjectMapper,
+			fcmTokenOrchestrator
 		);
 
 		initializeStream();
@@ -236,7 +241,8 @@ class ArticleRedisBatchProcessorIntegrationTest {
 			),
 			articleRepository,
 			mockBatchConfig,
-			optionalObjectMapper
+			optionalObjectMapper,
+			fcmTokenOrchestrator
 		);
 
 		consumerWithMockRedis.init();
@@ -256,7 +262,8 @@ class ArticleRedisBatchProcessorIntegrationTest {
 			mock(ReactiveRedisTemplate.class),
 			mock(ArticleRepository.class),
 			mock(BatchConfig.class),
-			optionalObjectMapper
+			optionalObjectMapper,
+			fcmTokenOrchestrator
 		);
 
 		Map<String, Object> status = consumerWithMockRedis.getBatchStatus();

--- a/src/test/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProcessorIntegrationTest.java
+++ b/src/test/java/com/newzet/api/article/repository/batch/ArticleRedisBatchProcessorIntegrationTest.java
@@ -92,9 +92,9 @@ class ArticleRedisBatchProcessorIntegrationTest {
 		consumer = new ArticleRedisBatchConsumerImpl(
 			redisTemplate,
 			reactiveRedisTemplate,
-			articleRepository,
 			mockBatchConfig,
 			optionalObjectMapper,
+			articleRepository,
 			fcmTokenOrchestrator
 		);
 
@@ -239,9 +239,9 @@ class ArticleRedisBatchProcessorIntegrationTest {
 				(ReactiveRedisConnectionFactory)redisConnectionFactory,
 				org.springframework.data.redis.serializer.RedisSerializationContext.string()
 			),
-			articleRepository,
 			mockBatchConfig,
 			optionalObjectMapper,
+			articleRepository,
 			fcmTokenOrchestrator
 		);
 
@@ -260,9 +260,9 @@ class ArticleRedisBatchProcessorIntegrationTest {
 		ArticleRedisBatchConsumerImpl consumerWithMockRedis = new ArticleRedisBatchConsumerImpl(
 			mockRedisTemplate,
 			mock(ReactiveRedisTemplate.class),
-			mock(ArticleRepository.class),
 			mock(BatchConfig.class),
 			optionalObjectMapper,
+			mock(ArticleRepository.class),
 			fcmTokenOrchestrator
 		);
 

--- a/src/test/java/com/newzet/api/config/FirebaseTestConfig.java
+++ b/src/test/java/com/newzet/api/config/FirebaseTestConfig.java
@@ -1,0 +1,45 @@
+package com.newzet.api.config;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class FirebaseTestConfig implements BeforeAllCallback {
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		System.setProperty("FIREBASE_PROJECT_ID", "test-project-id");
+		System.setProperty("FIREBASE_PRIVATE_KEY_ID", "test-private-key-id");
+		System.setProperty("FIREBASE_PRIVATE_KEY",
+			"-----BEGIN PRIVATE KEY-----\\n" +
+				"MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDHfbsrFLUnLmJg\\n" +
+				"tHqgmO4mcShpI37s10AH6TS4C9exfWcaoT4Ty7vY/fvhgHLpSEe3veqp2Rv8FkM7\\n" +
+				"yryeoT+VItgPDq7CAOmjaoshY/DTvsJXfbw6uZ4JWbD96gM4C2qoTHZcI0n+kAbB\\n" +
+				"TO3mvgH65GXQB5hGmuqDTacQ2eq5d2XOQV+OaiYKvEUUhnXCpleQjtimSt1HNoym\\n" +
+				"MPYg5YuPRpGMa2nQsSl+yPD1n/CtHOnVF8iJMN5D72lySjk5TmcUAaI6PRhJNxna\\n" +
+				"vKoVQYTmVoCcgfbNGVRfubfa0F/V/oO3rEGaqLmDim+9qH40Zxy/2p7OeIwXHLyt\\n" +
+				"+MzT+1p1AgMBAAECggEADYitT4gT8tNgmjtJodFDlY5navFHtaK0IIqaPdg+gGHy\\n" +
+				"bOnpL7z1LWIBxMk1l+JZoeYRCwfZ2wQu+ISnFO358HtmLr3/bir+BCJWIQ703Ntc\\n" +
+				"DO/QpX1H8vjHm1pVGz1vCs7xLWFkLjswMiIEISYyioZp6oScDeze9xx9YT/KKbMz\\n" +
+				"Ujc0rdAiWkHtar28HinQzLBl2Y2qUywD5gVl8GuzlMgrZO5eDlsHn8lQSWT6KsAq\\n" +
+				"DkoLjb+jkYVQvdf6kI/h99PDZITaHZXjIpyvQlxmYcILSPn1HvCH1FRIamiyDIjt\\n" +
+				"ZB1SynhlGmAy/KB6q49yzERKROYxI4z6YnwjWhTrWwKBgQD6btD595ZX5ocC0uXs\\n" +
+				"lXHMK7h2YRM6QXExHX+BT4Q3QDSg4Vl7fIv06qzjP+Wb+he7llHwSr3JAus55kuZ\\n" +
+				"+8pou13+Y4zBAKhtIOyuwtbIx2MoeZNQ5RT2pNHQmtbPnBBw6vLnNRBwKl7vdPfc\\n" +
+				"RI1m81i4czvDIJIYtee5nssVuwKBgQDL7QLts6VquHlB8vyGOg76KdtfJ4aLYIg8\\n" +
+				"GqKzFFNKNHbfjWIeRLqQJbLHNB/dljPlmqHZNyelyLH88jOW1OPveDKaMoLbPtiB\\n" +
+				"YSTAyqYwY9PMf/HRn5Dl1SejJzqvqPhMOLBlSASdXgvv7+XE7qnLY0AWIo3wRk8I\\n" +
+				"OTbsLTe1jwKBgQDm6P7vPQb3Daw3QlaWikVfSIDRRjkAYg8IhnZmuPbkKuNb4+0q\\n" +
+				"G3DA5xF6iBQiebsgUD5FHeVYTsStolbbKHs9jmXghdHms8CYvt79VNHOV2pqi471\\n" +
+				"7AQkV1zOx7aBvxi5xSkrXpZFlgvrJyLTirIG1yJbEIVuKb4L4s5DLNN8uQKBgA5g\\n" +
+				"9tzl1tsQiNRCmtWoEFhJTUOHWPBI7TI3upMf8sN/sYYPxQRXWkRBtDphjYGlTqF4\\n" +
+				"5sKXJf+FiC9KsKKI/k1rTz4aI6nr434z6FCDuXYeA9geiWF7e88I2ZOid3vdUSym\\n" +
+				"rqFlk5W5BOR1KOFa5rQFmoY1B4cSng35YssCYTQ3AoGBALlF2QZId/v6rRiwJJPp\\n" +
+				"kf1e9bNneLk6q/7JG+MQw+rSHzlLgrp+nRFi2jqjH32e7zFVSoaMunaqzncgLLfB\\n" +
+				"sIYKICkexMIt+Amg4y3a0xtdTbc5Qz439EEYYyGI162SOmrniMrM2XV3knUlEPOl\\n" +
+				"xDwsCn2Aig7xYK1Ac4FQPDNW\\n" +
+				"-----END PRIVATE KEY-----\\n"
+		);
+		System.setProperty("FIREBASE_CLIENT_EMAIL", "test@test-project.iam.gserviceaccount.com");
+		System.setProperty("FIREBASE_CLIENT_ID", "100768672478630755715");
+	}
+}

--- a/src/test/java/com/newzet/api/fcm/business/service/FcmSenderServiceTest.java
+++ b/src/test/java/com/newzet/api/fcm/business/service/FcmSenderServiceTest.java
@@ -1,0 +1,402 @@
+package com.newzet.api.fcm.business.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.newzet.api.fcm.business.batch.FcmBatchProducer;
+import com.newzet.api.fcm.business.repository.FcmTokenRepository;
+import com.newzet.api.fcm.domain.FcmNotification;
+import com.newzet.api.fcm.domain.FcmToken;
+
+@ExtendWith(MockitoExtension.class)
+public class FcmSenderServiceTest {
+
+	@Mock
+	private FcmBatchProducer batchProducer;
+
+	@Mock
+	private FcmTokenRepository fcmTokenRepository;
+
+	@Mock
+	private FirebaseMessaging firebaseMessaging;
+
+	@InjectMocks
+	private FcmSenderService fcmSenderService;
+
+	private UUID testUserId;
+	private String testFcmTokenValue;
+	private FcmToken testFcmToken;
+
+	@BeforeEach
+	void setUp() {
+		testUserId = UUID.randomUUID();
+		testFcmTokenValue = "test-fcm-token-value";
+		testFcmToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			testFcmTokenValue);
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenUserHasTokens_ThenSendNotifications() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken token1 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"token1");
+		FcmToken token2 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"token2");
+		List<FcmToken> tokens = List.of(token1, token2);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, times(2)).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenUserHasNoTokens_ThenNoNotificationsSent() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(List.of());
+
+		// When
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenTokenIsNull_ThenSkipInvalidNotification() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken tokenWithNullValue = new FcmToken(UUID.randomUUID(), LocalDateTime.now(),
+			testUserId,
+			null);
+		List<FcmToken> tokens = List.of(tokenWithNullValue);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenTokenIsEmpty_ThenSkipInvalidNotification() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken tokenWithEmptyValue = new FcmToken(UUID.randomUUID(), LocalDateTime.now(),
+			testUserId,
+			"");
+		List<FcmToken> tokens = List.of(tokenWithEmptyValue);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenMixedValidAndInvalidTokens_ThenProcessOnlyValidOnes() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken validToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"valid-token");
+		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			null);
+		List<FcmToken> tokens = List.of(validToken, invalidToken);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, times(1)).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenInvalidTokenFirst_ThenReturnEarly() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			null);
+		FcmToken validToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"valid-token");
+		List<FcmToken> tokens = List.of(invalidToken, validToken);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmNotBatch_WhenUserHasTokens_ThenSendDirectly() throws Exception {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken token1 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"token1");
+		List<FcmToken> tokens = List.of(token1);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+		when(firebaseMessaging.send(any(Message.class))).thenReturn("success-response");
+
+		// When
+		fcmSenderService.sendFcmNotBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(firebaseMessaging).send(any(Message.class));
+		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmNotBatch_WhenUserHasNoTokens_ThenNoNotificationsSent() throws
+		FirebaseMessagingException {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(List.of());
+
+		// When
+		fcmSenderService.sendFcmNotBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(firebaseMessaging, never()).send(any(Message.class));
+	}
+
+	@Test
+	void sendFcmNotBatch_WhenTokenIsInvalid_ThenSkipInvalidNotification() throws
+		FirebaseMessagingException {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			null);
+		List<FcmToken> tokens = List.of(invalidToken);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmSenderService.sendFcmNotBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(firebaseMessaging, never()).send(any(Message.class));
+	}
+
+	@Test
+	void sendFcmNotBatch_WhenInvalidTokenFirst_ThenReturnEarly() throws FirebaseMessagingException {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			null);
+		FcmToken validToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"valid-token");
+		List<FcmToken> tokens = List.of(invalidToken, validToken);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmSenderService.sendFcmNotBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(firebaseMessaging, never()).send(any(Message.class));
+	}
+
+	@Test
+	void send_WhenFcmNotificationIsValid_ThenSendSuccessfully() throws Exception {
+		// Given
+		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
+			"Newsletter", "New Article", null);
+		when(firebaseMessaging.send(any(Message.class))).thenReturn("success-response");
+
+		// When
+		fcmSenderService.send(notification);
+
+		// Then
+		verify(firebaseMessaging).send(any(Message.class));
+	}
+
+	@Test
+	void send_WhenFcmNotificationWithData_ThenSendSuccessfully() throws Exception {
+		// Given
+		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
+			"Newsletter", "New Article", "custom-data");
+		when(firebaseMessaging.send(any(Message.class))).thenReturn("success-response");
+
+		// When
+		fcmSenderService.send(notification);
+
+		// Then
+		verify(firebaseMessaging).send(any(Message.class));
+	}
+
+	@Test
+	void send_WhenInvalidTokenError_ThenDeleteToken() throws Exception {
+		// Given
+		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
+			"Newsletter", "New Article", null);
+		RuntimeException invalidTokenException = new RuntimeException("Invalid registration token");
+
+		when(firebaseMessaging.send(any(Message.class))).thenThrow(invalidTokenException);
+		when(fcmTokenRepository.findByUserIdAndValue(testUserId, testFcmTokenValue))
+			.thenReturn(testFcmToken);
+
+		// When
+		fcmSenderService.send(notification);
+
+		// Then
+		verify(firebaseMessaging).send(any(Message.class));
+		verify(fcmTokenRepository).findByUserIdAndValue(testUserId, testFcmTokenValue);
+		verify(fcmTokenRepository).deleteFcmToken(testFcmToken);
+	}
+
+	@Test
+	void send_WhenRegistrationTokenNotRegistered_ThenDeleteToken() throws Exception {
+		// Given
+		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
+			"Newsletter", "New Article", null);
+		RuntimeException notRegisteredError = new RuntimeException(
+			"Registration token not registered");
+
+		when(firebaseMessaging.send(any(Message.class))).thenThrow(notRegisteredError);
+		when(fcmTokenRepository.findByUserIdAndValue(testUserId, testFcmTokenValue))
+			.thenReturn(testFcmToken);
+
+		// When
+		fcmSenderService.send(notification);
+
+		// Then
+		verify(firebaseMessaging).send(any(Message.class));
+		verify(fcmTokenRepository).deleteFcmToken(testFcmToken);
+	}
+
+	@Test
+	void send_WhenInvalidArgumentError_ThenDeleteToken() throws Exception {
+		// Given
+		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
+			"Newsletter", "New Article", null);
+		RuntimeException invalidArgumentError = new RuntimeException("Invalid argument");
+
+		when(firebaseMessaging.send(any(Message.class))).thenThrow(invalidArgumentError);
+		when(fcmTokenRepository.findByUserIdAndValue(testUserId, testFcmTokenValue))
+			.thenReturn(testFcmToken);
+
+		// When
+		fcmSenderService.send(notification);
+
+		// Then
+		verify(firebaseMessaging).send(any(Message.class));
+		verify(fcmTokenRepository).deleteFcmToken(testFcmToken);
+	}
+
+	@Test
+	void send_WhenEntityNotFoundError_ThenDeleteToken() throws Exception {
+		// Given
+		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
+			"Newsletter", "New Article", null);
+		RuntimeException entityNotFoundError = new RuntimeException(
+			"Requested entity was not found");
+
+		when(firebaseMessaging.send(any(Message.class))).thenThrow(entityNotFoundError);
+		when(fcmTokenRepository.findByUserIdAndValue(testUserId, testFcmTokenValue))
+			.thenReturn(testFcmToken);
+
+		// When
+		fcmSenderService.send(notification);
+
+		// Then
+		verify(firebaseMessaging).send(any(Message.class));
+		verify(fcmTokenRepository).deleteFcmToken(testFcmToken);
+	}
+
+	@Test
+	void send_WhenOtherException_ThenDoNotDeleteToken() throws Exception {
+		// Given
+		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
+			"Newsletter", "New Article", null);
+		RuntimeException otherException = new RuntimeException("Network error");
+
+		when(firebaseMessaging.send(any(Message.class))).thenThrow(otherException);
+
+		// When
+		fcmSenderService.send(notification);
+
+		// Then
+		verify(firebaseMessaging).send(any(Message.class));
+		verify(fcmTokenRepository, never()).findByUserIdAndValue(any(), any());
+		verify(fcmTokenRepository, never()).deleteFcmToken(any());
+	}
+
+	@Test
+	void send_WhenDeleteTokenFails_ThenHandleGracefully() throws Exception {
+		// Given
+		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
+			"Newsletter", "New Article", null);
+		RuntimeException invalidTokenException = new RuntimeException("Invalid registration token");
+		RuntimeException deleteException = new RuntimeException("Database error");
+
+		when(firebaseMessaging.send(any(Message.class))).thenThrow(invalidTokenException);
+		when(fcmTokenRepository.findByUserIdAndValue(testUserId, testFcmTokenValue))
+			.thenReturn(testFcmToken);
+		doThrow(deleteException).when(fcmTokenRepository).deleteFcmToken(testFcmToken);
+
+		// When
+		fcmSenderService.send(notification);
+
+		// Then
+		verify(firebaseMessaging).send(any(Message.class));
+		verify(fcmTokenRepository).findByUserIdAndValue(testUserId, testFcmTokenValue);
+		verify(fcmTokenRepository).deleteFcmToken(testFcmToken);
+	}
+}

--- a/src/test/java/com/newzet/api/fcm/business/service/FcmTokenServiceTest.java
+++ b/src/test/java/com/newzet/api/fcm/business/service/FcmTokenServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.newzet.api.fcm.business.batch.FcmBatchProducer;
 import com.newzet.api.fcm.business.repository.FcmTokenRepository;
-import com.newzet.api.fcm.domain.FcmNotification;
 import com.newzet.api.fcm.domain.FcmToken;
 
 @ExtendWith(MockitoExtension.class)
@@ -94,104 +92,5 @@ class FcmTokenServiceTest {
 		// Then
 		verify(fcmTokenRepository).findByUserIdAndValue(testUserId, testFcmTokenValue);
 		verify(fcmTokenRepository).deleteFcmToken(testFcmToken);
-	}
-
-	@Test
-	void sendFcmWhenMailReceivedBatch_WhenUserHasTokens_ThenSendNotifications() {
-		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
-
-		FcmToken token1 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
-			"token1");
-		FcmToken token2 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
-			"token2");
-		List<FcmToken> tokens = List.of(token1, token2);
-
-		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
-
-		// When
-		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
-
-		// Then
-		verify(fcmTokenRepository).findAllByUserId(testUserId);
-		verify(batchProducer, times(2)).addToBatch(any(FcmNotification.class));
-	}
-
-	@Test
-	void sendFcmWhenMailReceivedBatch_WhenUserHasNoTokens_ThenNoNotificationsSent() {
-		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
-		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(List.of());
-
-		// When
-		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
-
-		// Then
-		verify(fcmTokenRepository).findAllByUserId(testUserId);
-		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
-	}
-
-	@Test
-	void sendFcmWhenMailReceivedBatch_WhenTokenIsNull_ThenSkipInvalidNotification() {
-		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
-		
-		FcmToken tokenWithNullValue = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
-			null);
-		List<FcmToken> tokens = List.of(tokenWithNullValue);
-
-		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
-
-		// When
-		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
-
-		// Then
-		verify(fcmTokenRepository).findAllByUserId(testUserId);
-		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
-	}
-
-	@Test
-	void sendFcmWhenMailReceivedBatch_WhenTokenIsEmpty_ThenSkipInvalidNotification() {
-		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
-		
-		FcmToken tokenWithEmptyValue = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
-			"");
-		List<FcmToken> tokens = List.of(tokenWithEmptyValue);
-
-		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
-
-		// When
-		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
-
-		// Then
-		verify(fcmTokenRepository).findAllByUserId(testUserId);
-		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
-	}
-
-	@Test
-	void sendFcmWhenMailReceivedBatch_WhenMixedValidAndInvalidTokens_ThenProcessOnlyValidOnes() {
-		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
-		
-		FcmToken validToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
-			"valid-token");
-		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
-			null);
-		List<FcmToken> tokens = List.of(validToken, invalidToken);
-
-		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
-
-		// When
-		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
-
-		// Then
-		verify(fcmTokenRepository).findAllByUserId(testUserId);
-		verify(batchProducer, times(1)).addToBatch(any(FcmNotification.class));
 	}
 }

--- a/src/test/java/com/newzet/api/fcm/business/service/FcmTokenServiceTest.java
+++ b/src/test/java/com/newzet/api/fcm/business/service/FcmTokenServiceTest.java
@@ -132,4 +132,66 @@ class FcmTokenServiceTest {
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
 		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
 	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenTokenIsNull_ThenSkipInvalidNotification() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+		
+		FcmToken tokenWithNullValue = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			null);
+		List<FcmToken> tokens = List.of(tokenWithNullValue);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenTokenIsEmpty_ThenSkipInvalidNotification() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+		
+		FcmToken tokenWithEmptyValue = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"");
+		List<FcmToken> tokens = List.of(tokenWithEmptyValue);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenMixedValidAndInvalidTokens_ThenProcessOnlyValidOnes() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+		
+		FcmToken validToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"valid-token");
+		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			null);
+		List<FcmToken> tokens = List.of(validToken, invalidToken);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, times(1)).addToBatch(any(FcmNotification.class));
+	}
 }

--- a/src/test/java/com/newzet/api/fcm/business/service/FcmTokenServiceTest.java
+++ b/src/test/java/com/newzet/api/fcm/business/service/FcmTokenServiceTest.java
@@ -1,0 +1,135 @@
+package com.newzet.api.fcm.business.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.newzet.api.fcm.business.batch.FcmBatchProducer;
+import com.newzet.api.fcm.business.repository.FcmTokenRepository;
+import com.newzet.api.fcm.domain.FcmNotification;
+import com.newzet.api.fcm.domain.FcmToken;
+
+@ExtendWith(MockitoExtension.class)
+class FcmTokenServiceTest {
+
+	@Mock
+	private FcmTokenRepository fcmTokenRepository;
+
+	@Mock
+	private FcmBatchProducer batchProducer;
+
+	@InjectMocks
+	private FcmTokenService fcmTokenService;
+
+	private UUID testUserId;
+	private String testFcmTokenValue;
+	private FcmToken testFcmToken;
+
+	@BeforeEach
+	void setUp() {
+		testUserId = UUID.randomUUID();
+		testFcmTokenValue = "test-fcm-token-value";
+		testFcmToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			testFcmTokenValue);
+	}
+
+	@Test
+	void upsertFcmToken_WhenTokenExists_ThenUpdateUserId() {
+		// Given
+		UUID existingUserId = UUID.randomUUID();
+		FcmToken existingToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(),
+			existingUserId, testFcmTokenValue);
+		FcmToken updatedToken = existingToken.changeUserId(testUserId);
+
+		when(fcmTokenRepository.findIfExistByValue(testFcmTokenValue)).thenReturn(
+			Optional.of(existingToken));
+		when(fcmTokenRepository.save(any(FcmToken.class))).thenReturn(updatedToken);
+
+		// When
+		FcmToken result = fcmTokenService.upsertFcmToken(testUserId, testFcmTokenValue);
+
+		// Then
+		assertThat(result.userId()).isEqualTo(testUserId);
+		assertThat(result.value()).isEqualTo(testFcmTokenValue);
+		verify(fcmTokenRepository).save(any(FcmToken.class));
+	}
+
+	@Test
+	void upsertFcmToken_WhenTokenNotExists_ThenCreateNew() {
+		// Given
+		when(fcmTokenRepository.findIfExistByValue(testFcmTokenValue)).thenReturn(Optional.empty());
+		when(fcmTokenRepository.save(any(FcmToken.class))).thenReturn(testFcmToken);
+
+		// When
+		FcmToken result = fcmTokenService.upsertFcmToken(testUserId, testFcmTokenValue);
+
+		// Then
+		assertThat(result.userId()).isEqualTo(testUserId);
+		assertThat(result.value()).isEqualTo(testFcmTokenValue);
+		verify(fcmTokenRepository).save(any(FcmToken.class));
+	}
+
+	@Test
+	void deleteFcmToken_WhenCalled_ThenDeleteToken() {
+		// Given
+		when(fcmTokenRepository.findByUserIdAndValue(testUserId, testFcmTokenValue)).thenReturn(
+			testFcmToken);
+		when(fcmTokenRepository.deleteFcmToken(testFcmToken)).thenReturn(true);
+
+		// When
+		fcmTokenService.deleteFcmToken(testUserId, testFcmTokenValue);
+
+		// Then
+		verify(fcmTokenRepository).findByUserIdAndValue(testUserId, testFcmTokenValue);
+		verify(fcmTokenRepository).deleteFcmToken(testFcmToken);
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenUserHasTokens_ThenSendNotifications() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+
+		FcmToken token1 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"token1");
+		FcmToken token2 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			"token2");
+		List<FcmToken> tokens = List.of(token1, token2);
+
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
+
+		// When
+		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, times(2)).addToBatch(any(FcmNotification.class));
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenUserHasNoTokens_ThenNoNotificationsSent() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(List.of());
+
+		// When
+		fcmTokenService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenRepository).findAllByUserId(testUserId);
+		verify(batchProducer, never()).addToBatch(any(FcmNotification.class));
+	}
+}

--- a/src/test/java/com/newzet/api/fcm/domain/FcmNotificationTest.java
+++ b/src/test/java/com/newzet/api/fcm/domain/FcmNotificationTest.java
@@ -1,0 +1,193 @@
+package com.newzet.api.fcm.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class FcmNotificationTest {
+
+	@Test
+	void create_WhenValidParameters_ThenCreateNotification() {
+		// Given
+		UUID userId = UUID.randomUUID();
+		String token = "test-fcm-token";
+		String title = "New Article";
+		String body = "You have a new article";
+		String data = "test-data";
+
+		// When
+		FcmNotification notification = FcmNotification.create(userId, token, title, body, data);
+
+		// Then
+		assertThat(notification.getUserId()).isEqualTo(userId);
+		assertThat(notification.getToken()).isEqualTo(token);
+		assertThat(notification.getTitle()).isEqualTo(title);
+		assertThat(notification.getBody()).isEqualTo(body);
+		assertThat(notification.getData()).isEqualTo(data);
+		assertThat(notification.getCreatedAt()).isNotNull();
+	}
+
+	@Test
+	void isValid_WhenTokenAndTitleNotEmpty_ThenReturnTrue() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			"test-token",
+			"Test Title",
+			"Test Body",
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isTrue();
+	}
+
+	@Test
+	void isValid_WhenTokenIsNull_ThenReturnFalse() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			null,
+			"Test Title",
+			"Test Body",
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	void isValid_WhenTokenIsEmpty_ThenReturnFalse() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			"",
+			"Test Title",
+			"Test Body",
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	void isValid_WhenTokenIsBlank_ThenReturnFalse() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			"   ",
+			"Test Title",
+			"Test Body",
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	void isValid_WhenTitleIsNull_ThenReturnFalse() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			"test-token",
+			null,
+			"Test Body",
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	void isValid_WhenTitleIsEmpty_ThenReturnFalse() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			"test-token",
+			"",
+			"Test Body",
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	void isValid_WhenTitleIsBlank_ThenReturnFalse() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			"test-token",
+			"   ",
+			"Test Body",
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	void isValid_WhenBodyIsNull_ThenReturnTrue() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			"test-token",
+			"Test Title",
+			null,
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isTrue();
+	}
+
+	@Test
+	void isValid_WhenDataIsNull_ThenReturnTrue() {
+		// Given
+		FcmNotification notification = FcmNotification.create(
+			UUID.randomUUID(),
+			"test-token",
+			"Test Title",
+			"Test Body",
+			null
+		);
+
+		// When
+		boolean isValid = notification.isValid();
+
+		// Then
+		assertThat(isValid).isTrue();
+	}
+}

--- a/src/test/java/com/newzet/api/fcm/domain/FcmTokenTest.java
+++ b/src/test/java/com/newzet/api/fcm/domain/FcmTokenTest.java
@@ -1,0 +1,69 @@
+package com.newzet.api.fcm.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class FcmTokenTest {
+
+	@Test
+	void create_WhenCalled_ThenCreateNewFcmToken() {
+		// Given
+		UUID userId = UUID.randomUUID();
+		String value = "test-fcm-token";
+
+		// When
+		FcmToken fcmToken = FcmToken.create(userId, value);
+
+		// Then
+		assertThat(fcmToken.id()).isNull();
+		assertThat(fcmToken.userId()).isEqualTo(userId);
+		assertThat(fcmToken.value()).isEqualTo(value);
+		assertThat(fcmToken.createdAt()).isNotNull();
+	}
+
+	@Test
+	void constructor_WhenCalled_ThenCreateFcmTokenWithAllFields() {
+		// Given
+		UUID id = UUID.randomUUID();
+		UUID userId = UUID.randomUUID();
+		String value = "test-fcm-token";
+		LocalDateTime createdAt = LocalDateTime.now();
+
+		// When
+		FcmToken fcmToken = new FcmToken(id, createdAt, userId, value);
+
+		// Then
+		assertThat(fcmToken.id()).isEqualTo(id);
+		assertThat(fcmToken.userId()).isEqualTo(userId);
+		assertThat(fcmToken.value()).isEqualTo(value);
+		assertThat(fcmToken.createdAt()).isEqualTo(createdAt);
+	}
+
+	@Test
+	void changeUserId_WhenCalled_ThenReturnNewTokenWithUpdatedUserId() {
+		// Given
+		UUID originalUserId = UUID.randomUUID();
+		UUID newUserId = UUID.randomUUID();
+		UUID id = UUID.randomUUID();
+		String value = "test-fcm-token";
+		LocalDateTime createdAt = LocalDateTime.now();
+
+		FcmToken originalToken = new FcmToken(id, createdAt, originalUserId, value);
+
+		// When
+		FcmToken updatedToken = originalToken.changeUserId(newUserId);
+
+		// Then
+		assertThat(updatedToken.id()).isEqualTo(id);
+		assertThat(updatedToken.userId()).isEqualTo(newUserId);
+		assertThat(updatedToken.value()).isEqualTo(value);
+		assertThat(updatedToken.createdAt()).isEqualTo(createdAt);
+
+		// Original token should remain unchanged
+		assertThat(originalToken.userId()).isEqualTo(originalUserId);
+	}
+}

--- a/src/test/java/com/newzet/api/fcm/jpa/repository/FcmTokenRepositoryTest.java
+++ b/src/test/java/com/newzet/api/fcm/jpa/repository/FcmTokenRepositoryTest.java
@@ -1,0 +1,158 @@
+package com.newzet.api.fcm.jpa.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.newzet.api.fcm.domain.FcmToken;
+import com.newzet.api.fcm.exception.NoFcmTokenException;
+import com.newzet.api.fcm.jpa.entity.FcmTokenEntity;
+
+@ExtendWith(MockitoExtension.class)
+class FcmTokenRepositoryTest {
+
+	@Mock
+	private FcmTokenJpaRepository fcmTokenJpaRepository;
+
+	@InjectMocks
+	private FcmTokenRepositoryImpl fcmTokenRepository;
+
+	private UUID testUserId;
+	private String testFcmToken;
+	private FcmTokenEntity testEntity;
+	private FcmToken testDomain;
+
+	@BeforeEach
+	void setUp() {
+		testUserId = UUID.randomUUID();
+		testFcmToken = "test-fcm-token-value";
+		testEntity = new FcmTokenEntity(UUID.randomUUID(), testUserId, testFcmToken,
+			LocalDateTime.now());
+		testDomain = new FcmToken(testEntity.getId(), testEntity.getCreatedAt(), testUserId,
+			testFcmToken);
+	}
+
+	@Test
+	void findIfExistByValue_WhenTokenExists_ThenReturnFcmToken() {
+		// Given
+		when(fcmTokenJpaRepository.findByFcmToken(testFcmToken)).thenReturn(
+			Optional.of(testEntity));
+
+		// When
+		Optional<FcmToken> result = fcmTokenRepository.findIfExistByValue(testFcmToken);
+
+		// Then
+		assertThat(result).isPresent();
+		assertThat(result.get().value()).isEqualTo(testFcmToken);
+		assertThat(result.get().userId()).isEqualTo(testUserId);
+	}
+
+	@Test
+	void findIfExistByValue_WhenTokenNotExists_ThenReturnEmpty() {
+		// Given
+		when(fcmTokenJpaRepository.findByFcmToken(testFcmToken)).thenReturn(Optional.empty());
+
+		// When
+		Optional<FcmToken> result = fcmTokenRepository.findIfExistByValue(testFcmToken);
+
+		// Then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void deleteFcmToken_WhenCalled_ThenReturnTrue() {
+		// Given
+		doNothing().when(fcmTokenJpaRepository).delete(any(FcmTokenEntity.class));
+
+		// When
+		boolean result = fcmTokenRepository.deleteFcmToken(testDomain);
+
+		// Then
+		assertThat(result).isTrue();
+		verify(fcmTokenJpaRepository).delete(any(FcmTokenEntity.class));
+	}
+
+	@Test
+	void save_WhenCalled_ThenReturnSavedFcmToken() {
+		// Given
+		when(fcmTokenJpaRepository.save(any(FcmTokenEntity.class))).thenReturn(testEntity);
+
+		// When
+		FcmToken result = fcmTokenRepository.save(testDomain);
+
+		// Then
+		assertThat(result.value()).isEqualTo(testFcmToken);
+		assertThat(result.userId()).isEqualTo(testUserId);
+		verify(fcmTokenJpaRepository).save(any(FcmTokenEntity.class));
+	}
+
+	@Test
+	void findByUserIdAndValue_WhenTokenExists_ThenReturnFcmToken() {
+		// Given
+		when(fcmTokenJpaRepository.findByUserIdAndFcmToken(testUserId, testFcmToken))
+			.thenReturn(Optional.of(testEntity));
+
+		// When
+		FcmToken result = fcmTokenRepository.findByUserIdAndValue(testUserId, testFcmToken);
+
+		// Then
+		assertThat(result.value()).isEqualTo(testFcmToken);
+		assertThat(result.userId()).isEqualTo(testUserId);
+	}
+
+	@Test
+	void findByUserIdAndValue_WhenTokenNotExists_ThenThrowException() {
+		// Given
+		when(fcmTokenJpaRepository.findByUserIdAndFcmToken(testUserId, testFcmToken))
+			.thenReturn(Optional.empty());
+
+		// When & Then
+		assertThatThrownBy(() -> fcmTokenRepository.findByUserIdAndValue(testUserId, testFcmToken))
+			.isInstanceOf(NoFcmTokenException.class)
+			.hasMessageContaining("FCM Token이 존재하지 않습니다");
+	}
+
+	@Test
+	void findAllByUserId_WhenTokensExist_ThenReturnTokenList() {
+		// Given
+		FcmTokenEntity entity1 = new FcmTokenEntity(UUID.randomUUID(), testUserId, "token1",
+			LocalDateTime.now());
+		FcmTokenEntity entity2 = new FcmTokenEntity(UUID.randomUUID(), testUserId, "token2",
+			LocalDateTime.now());
+		when(fcmTokenJpaRepository.findAllByUserId(testUserId)).thenReturn(
+			List.of(entity1, entity2));
+
+		// When
+		List<FcmToken> result = fcmTokenRepository.findAllByUserId(testUserId);
+
+		// Then
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).value()).isEqualTo("token1");
+		assertThat(result.get(1).value()).isEqualTo("token2");
+		assertThat(result).allMatch(token -> token.userId().equals(testUserId));
+	}
+
+	@Test
+	void findAllByUserId_WhenNoTokens_ThenReturnEmptyList() {
+		// Given
+		when(fcmTokenJpaRepository.findAllByUserId(testUserId)).thenReturn(List.of());
+
+		// When
+		List<FcmToken> result = fcmTokenRepository.findAllByUserId(testUserId);
+
+		// Then
+		assertThat(result).isEmpty();
+	}
+}

--- a/src/test/java/com/newzet/api/fcm/orchestrator/FcmSenderOrchestratorTest.java
+++ b/src/test/java/com/newzet/api/fcm/orchestrator/FcmSenderOrchestratorTest.java
@@ -12,17 +12,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.newzet.api.fcm.business.service.FcmTokenService;
+import com.newzet.api.fcm.business.service.FcmSenderService;
 import com.newzet.api.fcm.domain.FcmToken;
 
 @ExtendWith(MockitoExtension.class)
-class FcmTokenOrchestratorTest {
+public class FcmSenderOrchestratorTest {
 
 	@Mock
-	private FcmTokenService fcmTokenService;
+	private FcmSenderService fcmSenderService;
 
 	@InjectMocks
-	private FcmTokenOrchestrator fcmTokenOrchestrator;
+	private FcmSenderOrchestrator fcmSenderOrchestrator;
 
 	private UUID testUserId;
 	private String testFcmTokenValue;
@@ -37,27 +37,17 @@ class FcmTokenOrchestratorTest {
 	}
 
 	@Test
-	void upsertFcmToken_WhenCalled_ThenDelegateToService() {
+	void sendFcmWhenMailReceivedBatch_WhenCalled_ThenDelegateToService() {
 		// Given
-		when(fcmTokenService.upsertFcmToken(testUserId, testFcmTokenValue)).thenReturn(
-			testFcmToken);
+		String fromName = "Newsletter";
+		String title = "New Article";
+		doNothing().when(fcmSenderService)
+			.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
 
 		// When
-		fcmTokenOrchestrator.upsertFcmToken(testUserId, testFcmTokenValue);
+		fcmSenderOrchestrator.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
 
 		// Then
-		verify(fcmTokenService).upsertFcmToken(testUserId, testFcmTokenValue);
-	}
-
-	@Test
-	void deleteFcmToken_WhenCalled_ThenDelegateToService() {
-		// Given
-		doNothing().when(fcmTokenService).deleteFcmToken(testUserId, testFcmTokenValue);
-
-		// When
-		fcmTokenOrchestrator.deleteFcmToken(testUserId, testFcmTokenValue);
-
-		// Then
-		verify(fcmTokenService).deleteFcmToken(testUserId, testFcmTokenValue);
+		verify(fcmSenderService).sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
 	}
 }

--- a/src/test/java/com/newzet/api/fcm/orchestrator/FcmTokenOrchestratorTest.java
+++ b/src/test/java/com/newzet/api/fcm/orchestrator/FcmTokenOrchestratorTest.java
@@ -1,0 +1,77 @@
+package com.newzet.api.fcm.orchestrator;
+
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.newzet.api.fcm.business.service.FcmTokenService;
+import com.newzet.api.fcm.domain.FcmToken;
+
+@ExtendWith(MockitoExtension.class)
+class FcmTokenOrchestratorTest {
+
+	@Mock
+	private FcmTokenService fcmTokenService;
+
+	@InjectMocks
+	private FcmTokenOrchestrator fcmTokenOrchestrator;
+
+	private UUID testUserId;
+	private String testFcmTokenValue;
+	private FcmToken testFcmToken;
+
+	@BeforeEach
+	void setUp() {
+		testUserId = UUID.randomUUID();
+		testFcmTokenValue = "test-fcm-token-value";
+		testFcmToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
+			testFcmTokenValue);
+	}
+
+	@Test
+	void upsertFcmToken_WhenCalled_ThenDelegateToService() {
+		// Given
+		when(fcmTokenService.upsertFcmToken(testUserId, testFcmTokenValue)).thenReturn(
+			testFcmToken);
+
+		// When
+		fcmTokenOrchestrator.upsertFcmToken(testUserId, testFcmTokenValue);
+
+		// Then
+		verify(fcmTokenService).upsertFcmToken(testUserId, testFcmTokenValue);
+	}
+
+	@Test
+	void deleteFcmToken_WhenCalled_ThenDelegateToService() {
+		// Given
+		doNothing().when(fcmTokenService).deleteFcmToken(testUserId, testFcmTokenValue);
+
+		// When
+		fcmTokenOrchestrator.deleteFcmToken(testUserId, testFcmTokenValue);
+
+		// Then
+		verify(fcmTokenService).deleteFcmToken(testUserId, testFcmTokenValue);
+	}
+
+	@Test
+	void sendFcmWhenMailReceivedBatch_WhenCalled_ThenDelegateToService() {
+		// Given
+		String fromName = "Newsletter";
+		String title = "New Article";
+		doNothing().when(fcmTokenService).sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// When
+		fcmTokenOrchestrator.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+
+		// Then
+		verify(fcmTokenService).sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+	}
+}

--- a/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceConcurrencyTest.java
+++ b/src/test/java/com/newzet/api/newsletter/business/NewsletterServiceConcurrencyTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.newzet.api.common.cache.CacheUtil;
+import com.newzet.api.config.FirebaseTestConfig;
 import com.newzet.api.config.JwtTestConfig;
 import com.newzet.api.config.PostgresTestContainerConfig;
 import com.newzet.api.config.RedisTestContainerConfig;
@@ -31,7 +32,7 @@ import com.newzet.api.newsletter.repository.NewsletterJpaRepository;
 @Transactional
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ExtendWith({RedisTestContainerConfig.class, PostgresTestContainerConfig.class,
-	JwtTestConfig.class})
+	JwtTestConfig.class, FirebaseTestConfig.class})
 public class NewsletterServiceConcurrencyTest {
 
 	private final String name = "test";


### PR DESCRIPTION
# 개요
FCM 알림 전송을 위한 비동기 배치 처리 시스템 구현으로 대량 트래픽 상황에서 시스템 안정성 및 응답성 향상

# 배경
메일 서비스 특성상 단기간에 대량의 메일 수신이 발생하며, 각 메일 수신 시마다 FCM 알림을 전송해야 하는 상황이다. 
동기 처리 방식으로 구현한다면 다음과 같은 문제점이 발생할 것이다:

응답 지연: 메일 수신 → Article 저장 → FCM 전송이 모두 동기로 처리되어 사용자 **응답 시간이 급격히 증가**
시스템 부하: 대량 메일 수신 시 FCM API 호출이 **메인 애플리케이션 스레드를 블로킹**
장애 전파: FCM 전송 실패가 Article **저장 프로세스에 영향을 미쳐** 전체 시스템 불안정
메모리 부족: 대량의 FCM 요청을 **동시에 처리**할 때 **메모리 사용량 급증**

이러한 문제 발생을 방지하기 위해 비동기 배치 처리 시스템이 필요했다.

# 변경된 점
### 1. FCM 배치 처리 인터페이스 구조 설계

[Feat: BatchProducer와 BatchConsumer를 상속받아 인터페이스 Article용으로 제작](https://github.com/newzet-dev/mail-server/commit/a196fc1d3cc10794d74a279b9f0a3ddb015e82aa)
[Feat: BatchProducer와 BatchConsumer를 상속받은 FCM용 배치 인터페이스 생성](https://github.com/newzet-dev/mail-server/commit/597b15f33354fa360cf53892bafd9dcd4e0580e4)

- common에 정의된 배치 BatchProducer, BatchConsumer 인터페이스를 FCM 도메인에 맞게 상속하여 개별 인터페이스 제작
- FcmBatchProducer, FcmBatchConsumer 인터페이스를 통해 도메인별 배치 처리 구현
- 공통 인터페이스의 재사용성과 코드 통일성 향상, OCP(Open-Closed Principle) 원칙 준수

### 2. Redis Stream 기반 비동기 배치 처리 시스템 구현

**시스템 안정성 및 응답성 향상**

**Producer**: [Feat: FcmBatchProducer의 Redis 기반 구현체 추가](https://github.com/newzet-dev/mail-server/commit/08ee03bc20a8e48308d05865830635ea618063a0)

- FCM 알림 요청을 Redis Stream에 즉시 추가 후 응답 반환
- ReactiveRedisTemplate을 사용한 논블로킹 처리로 메인 스레드 영향 없음
- 유효하지 않은 알림에 대한 사전 검증 및 필터링

**Consumer**: [Feat: FcmBatchConsumer의 Redis 기반 구현체 추가](https://github.com/newzet-dev/mail-server/commit/b6abb99bbb5db07b64a8b799fba8398146df0e50)

- 전용 스레드 풀에서 배치 단위로 FCM 알림 처리
- Firebase Messaging API를 통한 실제 알림 전송
- 배치 크기 및 타임아웃 설정 기반 유연한 처리

**장애 격리 및 부하 분산**
- FCM 전송 실패가 Article 저장 프로세스에 영향을 주지 않음
- 단기간 대량 메일 수신 시 FCM 전송을 시간에 걸쳐 분산 처리
- Redis Stream을 통한 메모리 효율적인 큐 관리

### 3. FCM 토큰 관리 및 알림 전송용 아키텍쳐
**Repository Layer**: [Feat: 유저 ID 기반 FcmToken 전체 조회용 repo 구현체 메서드 추가](https://github.com/newzet-dev/mail-server/commit/88fa1886ffaca17850156fe58d52a5b8226f9f99)
- FCM 토큰의 CRUD 작업 처리
- 사용자별 토큰 조회 및 관리

**Service Layer**: [Feat: fcm 비즈니스 로직에 sendFcmWhenMailReceivedBatch 추가](https://github.com/newzet-dev/mail-server/commit/df81cd2185fc33bd7e8f19e1577dca499e8bdc4a)
- FCM 토큰 등록/갱신/삭제 비즈니스 로직
- 메일 수신 시 배치 알림 전송 처리
- 사용자당 다중 디바이스 지원 (중복 FCM 토큰 허용)

**Orchestrator Layer**: [Feat: FcmTokenOrchestrator에 하위 서비스단에서 추가된 로직 추가](https://github.com/newzet-dev/mail-server/commit/d27f2a781184ad040e23bf8308996da4c36fb944)
- 서비스 비즈니스 로직 기반 연결 매개체

**Controller Layer**: [Feat: fcm용 실시간 배치 처리 상태 모니터링 및 제어 api 제공 컨트롤러 추가](https://github.com/newzet-dev/mail-server/commit/925e0c657e4356abdb0c1736e455207bc5fcede4)
- FCM 토큰 관리 REST API 제공

### 4. 토큰 관리 및 실패 처리

[Feat: FcmBatchConsumer의 Redis 기반 구현체 추가](https://github.com/newzet-dev/mail-server/commit/b6abb99bbb5db07b64a8b799fba8398146df0e50)

[Feat: 배치 처리 결과 전달을 위한 클래스 추가](https://github.com/newzet-dev/mail-server/commit/10e6a4a23fa005bde9104faa04e34481b14fd63c)

- FCM 전송 실패 시 상세 로깅 처리
- 자동 토큰 정리: 유효하지 않은 토큰(만료/삭제된 앱) 자동 삭제로 불필요한 처리 방지
- 배치 처리 결과 통계 제공 (FcmBatchProcessingResult)

### 5. Article 도메인과의 완전한 비동기 연동

[Feat: Article 저장 성공 시 FCM 배치 처리 호출 로직 추가](https://github.com/newzet-dev/mail-server/commit/14aef60c7cc57bd0492f22ad29465d889d74f66d)

[Feat: FcmBatchConsumer의 Redis 기반 구현체 추가](https://github.com/newzet-dev/mail-server/commit/b6abb99bbb5db07b64a8b799fba8398146df0e50)

- Article 저장 완료 후 FCM 알림을 배치 큐에 추가만 하고 즉시 응답
- ArticleRedisBatchConsumerImpl에서 Article 저장 성공 시 FCM 배치 처리 호출
- 응답 시간 대폭 단축: 동기 FCM 전송 대기 시간 제거

## 참고자료
### 배치 처리 흐름 및 성능 이점
```
1. 메일 수신 → Article 도메인 배치 처리
2. Article 저장 성공 → FCM 알림 배치 큐에 추가 (비동기)
3. 즉시 사용자 응답 반환
4. 백그라운드에서 FCM 배치 Consumer가 일정 주기/크기로 알림 전송
5. 전송 실패 시 유효하지 않은 토큰 자동 삭제
```

### 핵심 성능 최적화 포인트
- Redis Stream을 통한 비동기 처리로 응답 시간 단축
- 장애 격리로 FCM 장애가 메일 처리에 영향 없음
- 배치 처리로 대량 트래픽 상황에서도 안정적 처리
- ReactiveRedisTemplate 사용으로 논블로킹 I/O 구현
- 실패한 토큰 자동 정리로 시스템 효율성 지속 향상 및 유저별 다중 디바이스 FCM Token 허용 가능

### Firebase 설정 관련 주의사항
firebase-service-account.json 파일을 resourses 하위에 두고 .gitignore에 추가한 상태
향후 컨테이너 환경에서 Firebase 인증 파일 마운트 작업으로 Docker Compose에서 사용할 수 있는 환경 구성 필요

### 로컬 환경에서 웹 기반 fcm 정상 작동 확인
![image](https://github.com/user-attachments/assets/fb019f2a-ea3c-43e6-9154-60b162cef803)

## 관련 이슈

close #88 
