### PR TITLE
이벤트 배너 API 구현

### DIFF
--- a/src/main/java/com/newzet/api/event/api/EventApi.java
+++ b/src/main/java/com/newzet/api/event/api/EventApi.java
@@ -1,0 +1,20 @@
+package com.newzet.api.event.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.newzet.api.common.response.SuccessResponse;
+import com.newzet.api.event.presentation.dto.EventListResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RequestMapping("/api/v1/event")
+@Tag(name = "이벤트 배너", description = "이벤트 배너 관련 API")
+public interface EventApi {
+
+	@GetMapping
+	@Operation(summary = "이벤트 배너 리스트 조회",
+		description = "모든 이벤트 배너 리스트를 조회한다.")
+	SuccessResponse<EventListResponse> getEventList();
+}

--- a/src/main/java/com/newzet/api/event/business/repository/EventQueryRepository.java
+++ b/src/main/java/com/newzet/api/event/business/repository/EventQueryRepository.java
@@ -1,0 +1,10 @@
+package com.newzet.api.event.business.repository;
+
+import java.util.List;
+
+import com.newzet.api.event.jpa.entity.EventEntity;
+
+public interface EventQueryRepository {
+
+	List<EventEntity> findEventListOrdered();
+}

--- a/src/main/java/com/newzet/api/event/business/repository/EventRepository.java
+++ b/src/main/java/com/newzet/api/event/business/repository/EventRepository.java
@@ -1,0 +1,10 @@
+package com.newzet.api.event.business.repository;
+
+import java.util.List;
+
+import com.newzet.api.event.domain.Event;
+
+public interface EventRepository {
+
+	List<Event> findEventList();
+}

--- a/src/main/java/com/newzet/api/event/business/service/EventService.java
+++ b/src/main/java/com/newzet/api/event/business/service/EventService.java
@@ -1,0 +1,23 @@
+package com.newzet.api.event.business.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.newzet.api.event.business.repository.EventRepository;
+import com.newzet.api.event.domain.Event;
+import com.newzet.api.event.presentation.dto.EventListResponse;
+import com.newzet.api.event.presentation.mapper.EventResponseMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+	private final EventRepository eventRepository;
+
+	EventListResponse getAllEvents() {
+		List<Event> eventList = eventRepository.findEventList();
+		return EventResponseMapper.toListResponse(eventList);
+	}
+}

--- a/src/main/java/com/newzet/api/event/business/service/EventService.java
+++ b/src/main/java/com/newzet/api/event/business/service/EventService.java
@@ -3,23 +3,18 @@ package com.newzet.api.event.business.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.newzet.api.event.business.repository.EventRepository;
 import com.newzet.api.event.domain.Event;
-import com.newzet.api.event.presentation.dto.EventListResponse;
-import com.newzet.api.event.presentation.mapper.EventResponseMapper;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class EventService {
 	private final EventRepository eventRepository;
 
-	public EventListResponse getAllEvents() {
-		List<Event> eventList = eventRepository.findEventList();
-		return EventResponseMapper.toListResponse(eventList);
+	public List<Event> getAllEvents() {
+		return eventRepository.findEventList();
 	}
 }

--- a/src/main/java/com/newzet/api/event/business/service/EventService.java
+++ b/src/main/java/com/newzet/api/event/business/service/EventService.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class EventService {
 	private final EventRepository eventRepository;
 
-	EventListResponse getAllEvents() {
+	public EventListResponse getAllEvents() {
 		List<Event> eventList = eventRepository.findEventList();
 		return EventResponseMapper.toListResponse(eventList);
 	}

--- a/src/main/java/com/newzet/api/event/business/service/EventService.java
+++ b/src/main/java/com/newzet/api/event/business/service/EventService.java
@@ -3,6 +3,7 @@ package com.newzet.api.event.business.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.newzet.api.event.business.repository.EventRepository;
 import com.newzet.api.event.domain.Event;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EventService {
 	private final EventRepository eventRepository;
 

--- a/src/main/java/com/newzet/api/event/domain/Event.java
+++ b/src/main/java/com/newzet/api/event/domain/Event.java
@@ -2,9 +2,19 @@ package com.newzet.api.event.domain;
 
 import java.util.UUID;
 
-public record Event(
-	UUID id,
-	String eventUrl,
-	String imageUrl
-) {
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class Event{
+	private final UUID id;
+	private final String eventUrl;
+	private final String imageUrl;
+
+	public static Event create(UUID id, String eventUrl, String imageUrl){
+		return new Event(id, eventUrl, imageUrl);
+	}
+
 }

--- a/src/main/java/com/newzet/api/event/domain/Event.java
+++ b/src/main/java/com/newzet/api/event/domain/Event.java
@@ -1,0 +1,10 @@
+package com.newzet.api.event.domain;
+
+import java.util.UUID;
+
+public record Event(
+	UUID id,
+	String eventUrl,
+	String imageUrl
+) {
+}

--- a/src/main/java/com/newzet/api/event/jpa/entity/EventEntity.java
+++ b/src/main/java/com/newzet/api/event/jpa/entity/EventEntity.java
@@ -1,0 +1,43 @@
+package com.newzet.api.event.jpa.entity;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "event_banner")
+public class EventEntity {
+
+	@Id
+	@UuidGenerator
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id;
+
+	@Column(name = "event_url", nullable = false)
+	private String eventUrl;
+
+	@Column(name = "image_url", nullable = false)
+	private String imageUrl;
+
+	@Column(name = "post_start")
+	private String postStart;
+
+	@Column(name = "post_end")
+	private String postEnd;
+
+	@Column(name = "priority")
+	private Integer priority;
+
+}

--- a/src/main/java/com/newzet/api/event/jpa/mapper/EventEntityMapper.java
+++ b/src/main/java/com/newzet/api/event/jpa/mapper/EventEntityMapper.java
@@ -6,7 +6,7 @@ import com.newzet.api.event.jpa.entity.EventEntity;
 public class EventEntityMapper {
 
 	public static Event toDomain(EventEntity eventEntity) {
-		return new Event(eventEntity.getId(), eventEntity.getEventUrl(), eventEntity.getImageUrl());
+		return Event.create(eventEntity.getId(), eventEntity.getEventUrl(), eventEntity.getImageUrl());
 	}
 
 }

--- a/src/main/java/com/newzet/api/event/jpa/mapper/EventEntityMapper.java
+++ b/src/main/java/com/newzet/api/event/jpa/mapper/EventEntityMapper.java
@@ -1,0 +1,12 @@
+package com.newzet.api.event.jpa.mapper;
+
+import com.newzet.api.event.domain.Event;
+import com.newzet.api.event.jpa.entity.EventEntity;
+
+public class EventEntityMapper {
+
+	public static Event toDomain(EventEntity eventEntity) {
+		return new Event(eventEntity.getId(), eventEntity.getEventUrl(), eventEntity.getImageUrl());
+	}
+
+}

--- a/src/main/java/com/newzet/api/event/jpa/repository/EventJpaQueryRepository.java
+++ b/src/main/java/com/newzet/api/event/jpa/repository/EventJpaQueryRepository.java
@@ -1,0 +1,35 @@
+package com.newzet.api.event.jpa.repository;
+
+import static com.newzet.api.event.jpa.entity.QEventEntity.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.newzet.api.event.business.repository.EventQueryRepository;
+import com.newzet.api.event.jpa.entity.EventEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class EventJpaQueryRepository implements EventQueryRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<EventEntity> findEventListOrdered() {
+		String currentTime = Instant.now().toString();
+
+		return jpaQueryFactory
+			.selectFrom(eventEntity)
+			.where(
+				eventEntity.postStart.lt(currentTime),
+				eventEntity.postEnd.gt(currentTime)
+			)
+			.orderBy(eventEntity.priority.asc())
+			.fetch();
+	}
+}

--- a/src/main/java/com/newzet/api/event/jpa/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/newzet/api/event/jpa/repository/EventRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.newzet.api.event.jpa.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.newzet.api.event.business.repository.EventQueryRepository;
+import com.newzet.api.event.business.repository.EventRepository;
+import com.newzet.api.event.domain.Event;
+import com.newzet.api.event.jpa.mapper.EventEntityMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class EventRepositoryImpl implements EventRepository {
+
+	private final EventQueryRepository eventQueryRepository;
+
+	@Override
+	public List<Event> findEventList() {
+		return eventQueryRepository.findEventListOrdered().stream()
+			.map(EventEntityMapper::toDomain)
+			.toList();
+	}
+}

--- a/src/main/java/com/newzet/api/event/orchestrator/EventOrchestrator.java
+++ b/src/main/java/com/newzet/api/event/orchestrator/EventOrchestrator.java
@@ -1,0 +1,22 @@
+package com.newzet.api.event.orchestrator;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newzet.api.event.business.service.EventService;
+import com.newzet.api.event.presentation.dto.EventListResponse;
+import com.newzet.api.event.presentation.mapper.EventResponseMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EventOrchestrator {
+
+	private final EventService eventService;
+
+	public EventListResponse getAllEvents() {
+		return EventResponseMapper.toListResponse(eventService.getAllEvents());
+	}
+}

--- a/src/main/java/com/newzet/api/event/presentation/controller/EventController.java
+++ b/src/main/java/com/newzet/api/event/presentation/controller/EventController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.newzet.api.common.response.ResponseCode;
 import com.newzet.api.common.response.SuccessResponse;
 import com.newzet.api.event.api.EventApi;
-import com.newzet.api.event.business.service.EventService;
+import com.newzet.api.event.orchestrator.EventOrchestrator;
 import com.newzet.api.event.presentation.dto.EventListResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -14,11 +14,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class EventController implements EventApi {
 
-	private final EventService eventService;
+	private final EventOrchestrator eventOrchestrator;
 
 	@Override
 	public SuccessResponse<EventListResponse> getEventList() {
-		EventListResponse eventList = eventService.getAllEvents();
+		EventListResponse eventList = eventOrchestrator.getAllEvents();
 		return SuccessResponse.create(ResponseCode.SUCCESS, "이벤트 리스트 조회 성공",
 			eventList);
 	}

--- a/src/main/java/com/newzet/api/event/presentation/controller/EventController.java
+++ b/src/main/java/com/newzet/api/event/presentation/controller/EventController.java
@@ -1,0 +1,25 @@
+package com.newzet.api.event.presentation.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import com.newzet.api.common.response.ResponseCode;
+import com.newzet.api.common.response.SuccessResponse;
+import com.newzet.api.event.api.EventApi;
+import com.newzet.api.event.business.service.EventService;
+import com.newzet.api.event.presentation.dto.EventListResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class EventController implements EventApi {
+
+	private final EventService eventService;
+
+	@Override
+	public SuccessResponse<EventListResponse> getEventList() {
+		EventListResponse eventList = eventService.getAllEvents();
+		return SuccessResponse.create(ResponseCode.SUCCESS, "이벤트 리스트 조회 성공",
+			eventList);
+	}
+}

--- a/src/main/java/com/newzet/api/event/presentation/dto/EventListResponse.java
+++ b/src/main/java/com/newzet/api/event/presentation/dto/EventListResponse.java
@@ -1,0 +1,8 @@
+package com.newzet.api.event.presentation.dto;
+
+import java.util.List;
+
+public record EventListResponse(
+	List<EventResponse> eventList
+) {
+}

--- a/src/main/java/com/newzet/api/event/presentation/dto/EventResponse.java
+++ b/src/main/java/com/newzet/api/event/presentation/dto/EventResponse.java
@@ -1,0 +1,7 @@
+package com.newzet.api.event.presentation.dto;
+
+public record EventResponse(
+	String imageUrl,
+	String eventUrl
+) {
+}

--- a/src/main/java/com/newzet/api/event/presentation/mapper/EventResponseMapper.java
+++ b/src/main/java/com/newzet/api/event/presentation/mapper/EventResponseMapper.java
@@ -10,7 +10,7 @@ public class EventResponseMapper {
 
 	public static EventListResponse toListResponse(List<Event> events) {
 		return new EventListResponse(events.stream()
-			.map(event -> new EventResponse(event.imageUrl(), event.eventUrl() ))
+			.map(event -> new EventResponse(event.getImageUrl(), event.getEventUrl() ))
 			.toList());
 	}
 }

--- a/src/main/java/com/newzet/api/event/presentation/mapper/EventResponseMapper.java
+++ b/src/main/java/com/newzet/api/event/presentation/mapper/EventResponseMapper.java
@@ -1,0 +1,16 @@
+package com.newzet.api.event.presentation.mapper;
+
+import java.util.List;
+
+import com.newzet.api.event.domain.Event;
+import com.newzet.api.event.presentation.dto.EventListResponse;
+import com.newzet.api.event.presentation.dto.EventResponse;
+
+public class EventResponseMapper {
+
+	public static EventListResponse toListResponse(List<Event> events) {
+		return new EventListResponse(events.stream()
+			.map(event -> new EventResponse(event.imageUrl(), event.eventUrl() ))
+			.toList());
+	}
+}

--- a/src/test/java/com/newzet/api/event/jpa/repository/EventRepositoryImplTest.java
+++ b/src/test/java/com/newzet/api/event/jpa/repository/EventRepositoryImplTest.java
@@ -1,0 +1,102 @@
+package com.newzet.api.event.jpa.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import com.newzet.api.config.PostgresTestContainerConfig;
+import com.newzet.api.config.db.QuerydslConfig;
+import com.newzet.api.event.business.repository.EventRepository;
+import com.newzet.api.event.domain.Event;
+import com.newzet.api.event.jpa.entity.EventEntity;
+
+@DataJpaTest
+@Import({EventRepositoryImpl.class, EventJpaQueryRepository.class, QuerydslConfig.class})
+@ExtendWith(PostgresTestContainerConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class EventRepositoryImplTest {
+
+	@Autowired
+	private EventRepository eventRepository;
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Test
+	@DisplayName("활성화된 이벤트 목록을 우선순위 순으로 정확히 조회한다")
+	void findEventListOrdered_shouldReturnActiveEvents_orderedByPriority() {
+		// given: 테스트 데이터 설정
+		Instant now = Instant.now();
+
+		// Case 1: 활성화된 이벤트 (우선순위 2) - 조회되어야 함
+		EventEntity activeEvent1 = new EventEntity(
+			null,
+			"https://event.com/active1",
+			"https://image.com/active1.png",
+			now.minus(1, ChronoUnit.DAYS).toString(),
+			now.plus(1, ChronoUnit.DAYS).toString(),
+			2
+		);
+
+		// Case 2: 활성화된 이벤트 (우선순위 1) - 조회되어야 하며, 가장 먼저 나와야 함
+		EventEntity activeEvent2 = new EventEntity(
+			null,
+			"https://event.com/active2",
+			"https://image.com/active2.png",
+			now.minus(2, ChronoUnit.DAYS).toString(),
+			now.plus(2, ChronoUnit.DAYS).toString(),
+			1
+		);
+
+		// Case 3: 종료된 이벤트 - 조회되지 않아야 함
+		EventEntity expiredEvent = new EventEntity(
+			null,
+			"https://event.com/expired",
+			"https://image.com/expired.png",
+			now.minus(10, ChronoUnit.DAYS).toString(),
+			now.minus(5, ChronoUnit.DAYS).toString(),
+			3
+		);
+
+		// Case 4: 시작 전 이벤트 - 조회되지 않아야 함
+		EventEntity upcomingEvent = new EventEntity(
+			null,
+			"https://event.com/upcoming",
+			"https://image.com/upcoming.png",
+			now.plus(5, ChronoUnit.DAYS).toString(),
+			now.plus(10, ChronoUnit.DAYS).toString(),
+			4
+		);
+
+		// TestEntityManager를 사용하여 DB에 저장
+		entityManager.persist(activeEvent1);
+		entityManager.persist(activeEvent2);
+		entityManager.persist(expiredEvent);
+		entityManager.persist(upcomingEvent);
+		entityManager.flush(); // DB에 변경사항 즉시 반영
+
+		// when
+		List<Event> foundEvents = eventRepository.findEventList();
+
+		// then
+		// 1. 활성화된 이벤트 2개만 조회되었는지 확인
+		assertThat(foundEvents).hasSize(2);
+
+		// 2. 우선순위(priority)가 낮은 순서(오름차순)로 정렬되었는지 확인
+		assertThat(foundEvents)
+			.extracting(Event::eventUrl)
+			.containsExactly("https://event.com/active2", "https://event.com/active1");
+	}
+
+}

--- a/src/test/java/com/newzet/api/event/jpa/repository/EventRepositoryImplTest.java
+++ b/src/test/java/com/newzet/api/event/jpa/repository/EventRepositoryImplTest.java
@@ -95,7 +95,7 @@ class EventRepositoryImplTest {
 
 		// 2. 우선순위(priority)가 낮은 순서(오름차순)로 정렬되었는지 확인
 		assertThat(foundEvents)
-			.extracting(Event::eventUrl)
+			.extracting(Event::getEventUrl)
 			.containsExactly("https://event.com/active2", "https://event.com/active1");
 	}
 


### PR DESCRIPTION
# 개요

- 이벤트 배너 API 구현

# 배경

- 기존 TS 서버에 구현된 이벤트 조회 API의 이전 필요

# 변경된 점

- 이벤트 전체 조회 API 구현
  - 기간이 끝났거나, 아직 시작되지 않은 이벤트는 리턴하지 않음
- 테스트 코드 작성
  - QueryDsl을 이용하여 쿼리 작성

## 참고자료

- 이벤트 레코드 개수가 적을 것을 고려하여, 별도의 최적화는 적용하지 않음

## 관련 이슈

close #90
