### PR TITLE
FCM 전송용 도메인 필드값 기존 TS 서버 내부 형식과 동기화

### DIFF
--- a/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
+++ b/src/main/java/com/newzet/api/article/repository/batch/ArticleRedisBatchConsumerImpl.java
@@ -182,7 +182,8 @@ public class ArticleRedisBatchConsumerImpl extends RedisBatchConsumer<Article>
 		if (!saved.isEmpty()) {
 			for (ArticleEntityDto articleData : saved) {
 				fcmSenderOrchestrator.sendFcmWhenMailReceivedBatch(articleData.getToUserId(),
-					articleData.getFromName(), articleData.getTitle());
+					articleData.getId(), articleData.getCreatedAt(),
+					articleData.getTitle(), articleData.getFromName());
 			}
 		}
 	}

--- a/src/main/java/com/newzet/api/fcm/business/service/FcmSenderService.java
+++ b/src/main/java/com/newzet/api/fcm/business/service/FcmSenderService.java
@@ -1,5 +1,6 @@
 package com.newzet.api.fcm.business.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -25,11 +26,12 @@ public class FcmSenderService {
 	private final FcmTokenRepository fcmTokenRepository;
 	private final FcmBatchProducer batchProducer;
 
-	public void sendFcmWhenMailReceivedBatch(UUID userId, String fromName, String title) {
+	public void sendFcmWhenMailReceivedBatch(UUID userId, UUID articleId,
+		LocalDateTime articleCreatedAt, String articleTitle, String newsletterName) {
 		List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUserId(userId);
 		for (FcmToken fcmToken : fcmTokens) {
 			FcmNotification fcmNotification = FcmNotification.create(userId, fcmToken.value(),
-				fromName, title, null);
+				articleId, articleCreatedAt, articleTitle, newsletterName);
 			if (!fcmNotification.isValid()) {
 				log.warn("Invalid FCM notification, skipping: userId={}, token={}",
 					fcmNotification.getUserId(), fcmNotification.getToken());
@@ -39,11 +41,12 @@ public class FcmSenderService {
 		}
 	}
 
-	public void sendFcmNotBatch(UUID userId, String fromName, String title) {
+	public void sendFcmNotBatch(UUID userId, UUID articleId,
+		LocalDateTime articleCreatedAt, String articleTitle, String newsletterName) {
 		List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUserId(userId);
 		for (FcmToken fcmToken : fcmTokens) {
 			FcmNotification fcmNotification = FcmNotification.create(userId, fcmToken.value(),
-				fromName, title, null);
+				articleId, articleCreatedAt, articleTitle, newsletterName);
 			if (!fcmNotification.isValid()) {
 				log.warn("Invalid FCM notification, skipping: userId={}, token={}",
 					fcmNotification.getUserId(), fcmNotification.getToken());
@@ -66,10 +69,11 @@ public class FcmSenderService {
 		return Message.builder()
 			.setToken(fcmNotification.getToken())
 			.setNotification(Notification.builder()
-				.setTitle(fcmNotification.getTitle())
-				.setBody(fcmNotification.getBody())
+				.setTitle(fcmNotification.getNewsletterName())
+				.setBody(fcmNotification.getArticleTitle())
 				.build())
-			.putData("data", fcmNotification.getData() != null ? fcmNotification.getData() : "")
+			.putData("articleId", fcmNotification.getArticleId().toString())
+			.putData("articleCreatedAt", fcmNotification.getArticleCreatedAt().toString())
 			.build();
 	}
 

--- a/src/main/java/com/newzet/api/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/newzet/api/fcm/domain/FcmNotification.java
@@ -12,25 +12,25 @@ import lombok.Getter;
 public class FcmNotification {
 	private UUID userId;
 	private String token;
-	private String title;
-	private String body;
-	private String data;
-	private LocalDateTime createdAt;
+	private UUID articleId;
+	private LocalDateTime articleCreatedAt;
+	private String articleTitle;
+	private String newsletterName;
 
-	public static FcmNotification create(UUID userId, String token, String title, String body,
-		String data) {
+	public static FcmNotification create(UUID userId, String token, UUID articleId,
+		LocalDateTime articleCreatedAt,
+		String articleTitle, String newsletterName) {
 		return new FcmNotification(
 			userId,
 			token,
-			title,
-			body,
-			data,
-			LocalDateTime.now()
-		);
+			articleId,
+			articleCreatedAt,
+			articleTitle,
+			newsletterName);
 	}
 
 	public boolean isValid() {
 		return token != null && !token.trim().isEmpty()
-			&& title != null && !title.trim().isEmpty();
+			&& articleTitle != null && !articleTitle.trim().isEmpty();
 	}
 }

--- a/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
+++ b/src/main/java/com/newzet/api/fcm/jpa/batch/FcmRedisBatchProducerImpl.java
@@ -35,6 +35,6 @@ public class FcmRedisBatchProducerImpl extends RedisBatchProducer<FcmNotificatio
 	@Override
 	protected String getItemIdentifier(FcmNotification fcmNotification) {
 		return String.format("userId=%s, title=%s", fcmNotification.getUserId(),
-			fcmNotification.getTitle());
+			fcmNotification.getArticleTitle());
 	}
 }

--- a/src/main/java/com/newzet/api/fcm/orchestrator/FcmSenderOrchestrator.java
+++ b/src/main/java/com/newzet/api/fcm/orchestrator/FcmSenderOrchestrator.java
@@ -1,5 +1,6 @@
 package com.newzet.api.fcm.orchestrator;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -17,12 +18,16 @@ public class FcmSenderOrchestrator {
 
 	private final FcmSenderService fcmSenderService;
 
-	public void sendFcmWhenMailReceivedBatch(UUID userId, String fromName, String title) {
-		fcmSenderService.sendFcmWhenMailReceivedBatch(userId, fromName, title);
+	public void sendFcmWhenMailReceivedBatch(UUID userId, UUID articleId,
+		LocalDateTime articleCreatedAt, String articleTitle, String newsletterName) {
+		fcmSenderService.sendFcmWhenMailReceivedBatch(userId, articleId, articleCreatedAt,
+			articleTitle, newsletterName);
 	}
 
-	public void sendFcmNotBatch(UUID userId, String fromName, String title) {
-		fcmSenderService.sendFcmNotBatch(userId, fromName, title);
+	public void sendFcmNotBatch(UUID userId, UUID articleId,
+		LocalDateTime articleCreatedAt, String articleTitle, String newsletterName) {
+		fcmSenderService.sendFcmNotBatch(userId, articleId, articleCreatedAt,
+			articleTitle, newsletterName);
 	}
 
 	public void send(FcmNotification fcmNotification) { // Consumer 이외에서 사용 금지

--- a/src/test/java/com/newzet/api/fcm/business/service/FcmSenderServiceTest.java
+++ b/src/test/java/com/newzet/api/fcm/business/service/FcmSenderServiceTest.java
@@ -52,8 +52,10 @@ public class FcmSenderServiceTest {
 	@Test
 	void sendFcmWhenMailReceivedBatch_WhenUserHasTokens_ThenSendNotifications() {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 
 		FcmToken token1 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
 			"token1");
@@ -64,7 +66,8 @@ public class FcmSenderServiceTest {
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
 
 		// When
-		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -74,12 +77,15 @@ public class FcmSenderServiceTest {
 	@Test
 	void sendFcmWhenMailReceivedBatch_WhenUserHasNoTokens_ThenNoNotificationsSent() {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(List.of());
 
 		// When
-		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -89,8 +95,10 @@ public class FcmSenderServiceTest {
 	@Test
 	void sendFcmWhenMailReceivedBatch_WhenTokenIsNull_ThenSkipInvalidNotification() {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 
 		FcmToken tokenWithNullValue = new FcmToken(UUID.randomUUID(), LocalDateTime.now(),
 			testUserId,
@@ -100,7 +108,8 @@ public class FcmSenderServiceTest {
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
 
 		// When
-		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -110,8 +119,10 @@ public class FcmSenderServiceTest {
 	@Test
 	void sendFcmWhenMailReceivedBatch_WhenTokenIsEmpty_ThenSkipInvalidNotification() {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 
 		FcmToken tokenWithEmptyValue = new FcmToken(UUID.randomUUID(), LocalDateTime.now(),
 			testUserId,
@@ -121,7 +132,8 @@ public class FcmSenderServiceTest {
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
 
 		// When
-		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -131,8 +143,10 @@ public class FcmSenderServiceTest {
 	@Test
 	void sendFcmWhenMailReceivedBatch_WhenMixedValidAndInvalidTokens_ThenProcessOnlyValidOnes() {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 
 		FcmToken validToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
 			"valid-token");
@@ -143,7 +157,8 @@ public class FcmSenderServiceTest {
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
 
 		// When
-		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -153,8 +168,10 @@ public class FcmSenderServiceTest {
 	@Test
 	void sendFcmWhenMailReceivedBatch_WhenInvalidTokenFirst_ThenReturnEarly() {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 
 		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
 			null);
@@ -165,7 +182,8 @@ public class FcmSenderServiceTest {
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
 
 		// When
-		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmWhenMailReceivedBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -175,8 +193,10 @@ public class FcmSenderServiceTest {
 	@Test
 	void sendFcmNotBatch_WhenUserHasTokens_ThenSendDirectly() throws Exception {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 
 		FcmToken token1 = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
 			"token1");
@@ -186,7 +206,8 @@ public class FcmSenderServiceTest {
 		when(firebaseMessaging.send(any(Message.class))).thenReturn("success-response");
 
 		// When
-		fcmSenderService.sendFcmNotBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmNotBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -198,12 +219,15 @@ public class FcmSenderServiceTest {
 	void sendFcmNotBatch_WhenUserHasNoTokens_ThenNoNotificationsSent() throws
 		FirebaseMessagingException {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(List.of());
 
 		// When
-		fcmSenderService.sendFcmNotBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmNotBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -214,8 +238,10 @@ public class FcmSenderServiceTest {
 	void sendFcmNotBatch_WhenTokenIsInvalid_ThenSkipInvalidNotification() throws
 		FirebaseMessagingException {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 
 		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
 			null);
@@ -224,7 +250,8 @@ public class FcmSenderServiceTest {
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
 
 		// When
-		fcmSenderService.sendFcmNotBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmNotBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -234,8 +261,10 @@ public class FcmSenderServiceTest {
 	@Test
 	void sendFcmNotBatch_WhenInvalidTokenFirst_ThenReturnEarly() throws FirebaseMessagingException {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 
 		FcmToken invalidToken = new FcmToken(UUID.randomUUID(), LocalDateTime.now(), testUserId,
 			null);
@@ -246,7 +275,8 @@ public class FcmSenderServiceTest {
 		when(fcmTokenRepository.findAllByUserId(testUserId)).thenReturn(tokens);
 
 		// When
-		fcmSenderService.sendFcmNotBatch(testUserId, fromName, title);
+		fcmSenderService.sendFcmNotBatch(testUserId, articleId, 
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		verify(fcmTokenRepository).findAllByUserId(testUserId);
@@ -257,7 +287,7 @@ public class FcmSenderServiceTest {
 	void send_WhenFcmNotificationIsValid_ThenSendSuccessfully() throws Exception {
 		// Given
 		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
-			"Newsletter", "New Article", null);
+			UUID.randomUUID(), LocalDateTime.now(), "New Article", "Newsletter");
 		when(firebaseMessaging.send(any(Message.class))).thenReturn("success-response");
 
 		// When
@@ -271,7 +301,7 @@ public class FcmSenderServiceTest {
 	void send_WhenFcmNotificationWithData_ThenSendSuccessfully() throws Exception {
 		// Given
 		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
-			"Newsletter", "New Article", "custom-data");
+			UUID.randomUUID(), LocalDateTime.now(), "New Article", "Newsletter");
 		when(firebaseMessaging.send(any(Message.class))).thenReturn("success-response");
 
 		// When
@@ -285,7 +315,7 @@ public class FcmSenderServiceTest {
 	void send_WhenInvalidTokenError_ThenDeleteToken() throws Exception {
 		// Given
 		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
-			"Newsletter", "New Article", null);
+			UUID.randomUUID(), LocalDateTime.now(), "New Article", "Newsletter");
 		RuntimeException invalidTokenException = new RuntimeException("Invalid registration token");
 
 		when(firebaseMessaging.send(any(Message.class))).thenThrow(invalidTokenException);
@@ -305,7 +335,7 @@ public class FcmSenderServiceTest {
 	void send_WhenRegistrationTokenNotRegistered_ThenDeleteToken() throws Exception {
 		// Given
 		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
-			"Newsletter", "New Article", null);
+			UUID.randomUUID(), LocalDateTime.now(), "New Article", "Newsletter");
 		RuntimeException notRegisteredError = new RuntimeException(
 			"Registration token not registered");
 
@@ -325,7 +355,7 @@ public class FcmSenderServiceTest {
 	void send_WhenInvalidArgumentError_ThenDeleteToken() throws Exception {
 		// Given
 		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
-			"Newsletter", "New Article", null);
+			UUID.randomUUID(), LocalDateTime.now(), "New Article", "Newsletter");
 		RuntimeException invalidArgumentError = new RuntimeException("Invalid argument");
 
 		when(firebaseMessaging.send(any(Message.class))).thenThrow(invalidArgumentError);
@@ -344,7 +374,7 @@ public class FcmSenderServiceTest {
 	void send_WhenEntityNotFoundError_ThenDeleteToken() throws Exception {
 		// Given
 		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
-			"Newsletter", "New Article", null);
+			UUID.randomUUID(), LocalDateTime.now(), "New Article", "Newsletter");
 		RuntimeException entityNotFoundError = new RuntimeException(
 			"Requested entity was not found");
 
@@ -364,7 +394,7 @@ public class FcmSenderServiceTest {
 	void send_WhenOtherException_ThenDoNotDeleteToken() throws Exception {
 		// Given
 		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
-			"Newsletter", "New Article", null);
+			UUID.randomUUID(), LocalDateTime.now(), "New Article", "Newsletter");
 		RuntimeException otherException = new RuntimeException("Network error");
 
 		when(firebaseMessaging.send(any(Message.class))).thenThrow(otherException);
@@ -382,7 +412,7 @@ public class FcmSenderServiceTest {
 	void send_WhenDeleteTokenFails_ThenHandleGracefully() throws Exception {
 		// Given
 		FcmNotification notification = FcmNotification.create(testUserId, testFcmTokenValue,
-			"Newsletter", "New Article", null);
+			UUID.randomUUID(), LocalDateTime.now(), "New Article", "Newsletter");
 		RuntimeException invalidTokenException = new RuntimeException("Invalid registration token");
 		RuntimeException deleteException = new RuntimeException("Database error");
 

--- a/src/test/java/com/newzet/api/fcm/domain/FcmNotificationTest.java
+++ b/src/test/java/com/newzet/api/fcm/domain/FcmNotificationTest.java
@@ -2,6 +2,7 @@ package com.newzet.api.fcm.domain;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -13,20 +14,22 @@ class FcmNotificationTest {
 		// Given
 		UUID userId = UUID.randomUUID();
 		String token = "test-fcm-token";
-		String title = "New Article";
-		String body = "You have a new article";
-		String data = "test-data";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Test Newsletter";
 
 		// When
-		FcmNotification notification = FcmNotification.create(userId, token, title, body, data);
+		FcmNotification notification = FcmNotification.create(userId, token, articleId,
+			articleCreatedAt, articleTitle, newsletterName);
 
 		// Then
 		assertThat(notification.getUserId()).isEqualTo(userId);
 		assertThat(notification.getToken()).isEqualTo(token);
-		assertThat(notification.getTitle()).isEqualTo(title);
-		assertThat(notification.getBody()).isEqualTo(body);
-		assertThat(notification.getData()).isEqualTo(data);
-		assertThat(notification.getCreatedAt()).isNotNull();
+		assertThat(notification.getArticleId()).isEqualTo(articleId);
+		assertThat(notification.getArticleCreatedAt()).isEqualTo(articleCreatedAt);
+		assertThat(notification.getArticleTitle()).isEqualTo(articleTitle);
+		assertThat(notification.getNewsletterName()).isEqualTo(newsletterName);
 	}
 
 	@Test
@@ -35,9 +38,10 @@ class FcmNotificationTest {
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			"test-token",
+			UUID.randomUUID(),
+			LocalDateTime.now(),
 			"Test Title",
-			"Test Body",
-			null
+			"Test Newsletter"
 		);
 
 		// When
@@ -53,9 +57,10 @@ class FcmNotificationTest {
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			null,
+			UUID.randomUUID(),
+			LocalDateTime.now(),
 			"Test Title",
-			"Test Body",
-			null
+			"Test Newsletter"
 		);
 
 		// When
@@ -71,9 +76,10 @@ class FcmNotificationTest {
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			"",
+			UUID.randomUUID(),
+			LocalDateTime.now(),
 			"Test Title",
-			"Test Body",
-			null
+			"Test Newsletter"
 		);
 
 		// When
@@ -89,9 +95,10 @@ class FcmNotificationTest {
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			"   ",
+			UUID.randomUUID(),
+			LocalDateTime.now(),
 			"Test Title",
-			"Test Body",
-			null
+			"Test Newsletter"
 		);
 
 		// When
@@ -107,9 +114,10 @@ class FcmNotificationTest {
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			"test-token",
+			UUID.randomUUID(),
+			LocalDateTime.now(),
 			null,
-			"Test Body",
-			null
+			"Test Newsletter"
 		);
 
 		// When
@@ -125,9 +133,10 @@ class FcmNotificationTest {
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			"test-token",
+			UUID.randomUUID(),
+			LocalDateTime.now(),
 			"",
-			"Test Body",
-			null
+			"Test Newsletter"
 		);
 
 		// When
@@ -143,9 +152,10 @@ class FcmNotificationTest {
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			"test-token",
+			UUID.randomUUID(),
+			LocalDateTime.now(),
 			"   ",
-			"Test Body",
-			null
+			"Test Newsletter"
 		);
 
 		// When
@@ -156,13 +166,14 @@ class FcmNotificationTest {
 	}
 
 	@Test
-	void isValid_WhenBodyIsNull_ThenReturnTrue() {
+	void isValid_WhenNewsletterNameIsNull_ThenReturnTrue() {
 		// Given
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			"test-token",
+			UUID.randomUUID(),
+			LocalDateTime.now(),
 			"Test Title",
-			null,
 			null
 		);
 
@@ -174,14 +185,15 @@ class FcmNotificationTest {
 	}
 
 	@Test
-	void isValid_WhenDataIsNull_ThenReturnTrue() {
+	void isValid_WhenArticleIdIsNull_ThenReturnTrue() {
 		// Given
 		FcmNotification notification = FcmNotification.create(
 			UUID.randomUUID(),
 			"test-token",
+			null,
+			LocalDateTime.now(),
 			"Test Title",
-			"Test Body",
-			null
+			"Test Newsletter"
 		);
 
 		// When

--- a/src/test/java/com/newzet/api/fcm/orchestrator/FcmSenderOrchestratorTest.java
+++ b/src/test/java/com/newzet/api/fcm/orchestrator/FcmSenderOrchestratorTest.java
@@ -39,15 +39,20 @@ public class FcmSenderOrchestratorTest {
 	@Test
 	void sendFcmWhenMailReceivedBatch_WhenCalled_ThenDelegateToService() {
 		// Given
-		String fromName = "Newsletter";
-		String title = "New Article";
+		UUID articleId = UUID.randomUUID();
+		LocalDateTime articleCreatedAt = LocalDateTime.now();
+		String articleTitle = "New Article";
+		String newsletterName = "Newsletter";
 		doNothing().when(fcmSenderService)
-			.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+			.sendFcmWhenMailReceivedBatch(testUserId, articleId, articleCreatedAt, articleTitle,
+				newsletterName);
 
 		// When
-		fcmSenderOrchestrator.sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+		fcmSenderOrchestrator.sendFcmWhenMailReceivedBatch(testUserId, articleId, articleCreatedAt,
+			articleTitle, newsletterName);
 
 		// Then
-		verify(fcmSenderService).sendFcmWhenMailReceivedBatch(testUserId, fromName, title);
+		verify(fcmSenderService).sendFcmWhenMailReceivedBatch(testUserId, articleId,
+			articleCreatedAt, articleTitle, newsletterName);
 	}
 }


### PR DESCRIPTION
# 개요
FCM 전송용 도메인 필드값 기존 TS 서버 내부 형식과 동일하게 변경하여 서버 이전시 발생할 수 있는 FCM 형식 관련 문제를 해소

# 배경
현재 Spring 서버의 FCM 도메인 형식과 TS 서버의 FCM 도메인 형식이 다름

[TS 서버의 FCM 도메인 형식](https://github.com/Gyu-won/Newzet-TS-Server/blob/develop/supabase/functions/fcm_hook/index.ts#L122)

```
interface FcmNotificationRecord {
  id: string;
  user_id: string;
  article_id: string;
  article_created_at: string;
  article_title: string;
  newsletter_name: string;
}
```
```
 body: JSON.stringify({
          message: {
            token: fcmToken,
            data: {
              articleId: record.article_id,
              articleCreatedAt: record.article_created_at,
            },
            notification: {
              title: record.newsletter_name,
              body: record.article_title,
            },
          }

```

# 변경된 점
#### FcmNotification 도메인 필드 형식 TS 서버와 통일하도록 변경
```
public class FcmNotification {
	private UUID userId;
	private String token;
	private UUID articleId;
	private LocalDateTime articleCreatedAt;
	private String articleTitle;
	private String newsletterName;
}
```
#### 전송시 보내는 필드값 통일
```
private Message buildFcmMessage(FcmNotification fcmNotification) {
  return Message.builder()
	.setToken(fcmNotification.getToken())
	.setNotification(Notification.builder()
		.setTitle(fcmNotification.getNewsletterName())
		.setBody(fcmNotification.getArticleTitle())
		.build())
	.putData("articleId", fcmNotification.getArticleId().toString())
	.putData("articleCreatedAt", fcmNotification.getArticleCreatedAt().toString())
	.build();
}
```

> 참고) TS server에서는 전송한 FCM에 대한 DB 저장로직이 존재하는데, 해당 로직의 오버헤드와 이후 활용빈도를 고려해 보았을 때 성능상 삭제하는것의 이점이 크다고 생각하여 따로 Spring 서버에 옮기지 않았습니다. 이후, 이와 관련한 추가가 필요한 경우 논의 후 추가를 고려해보면 좋을 것 같습니다.

## 참고자료
#### 로컬 테스트 결과
![image](https://github.com/user-attachments/assets/6609cb11-6a3b-4ac3-940a-d447701d4fcf)
![image](https://github.com/user-attachments/assets/12724904-1451-4839-8f7f-277c01c5447c)

## 관련 이슈

close #96 