### PR TITLE
JAVA 버전 17 -> 21로 업그레이드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
       - name: get repository code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,10 +13,10 @@ jobs:
       - name: get repository code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:21
 RUN mkdir -p /usr/local/newrelic
 
 ARG JAR_FILE=build/libs/*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 


### PR DESCRIPTION
# 개요
스프링 서버의 자바 버전을 17에서 21로 업그레이드 한다

# 배경
자바 21의 기능들 (ex. 가상쓰레드 등)을 활용하기 위해 자바 버전 업그레이드가 필요

# 변경된 점
- gradle 빌드 java 21로 변경
- docker 빌드용 파일 java 21로 변경
- ci, ci-cd 워크플로우 java 21로 변경

## 참고자료
<img width="1906" height="973" alt="image" src="https://github.com/user-attachments/assets/72fd2bcb-7edc-45e1-a3f1-00233876930d" />
<img width="1726" height="534" alt="image" src="https://github.com/user-attachments/assets/f9bb8520-0671-4801-a7af-e3f0c25bf2b0" />

도커 및 인텔리제이 기반 정상 실행 확인

## 관련 이슈
close #101 
