### PR TITLE
dev 브랜치용 dev서버 연결 및 CI/CD

### DIFF
--- a/.github/workflows/dev_ci_cd.yml
+++ b/.github/workflows/dev_ci_cd.yml
@@ -1,0 +1,74 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - dev
+      - Deploy/issue-#109
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_NAME: easyho3/newzet-spring-server
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.DEV_GCP_SERVICE_ACCOUNT_KEY }}'
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: eminent-ember-468115-i1
+
+      - name: Download New Relic Files from GCS
+        run: |
+          mkdir -p newrelic
+          gsutil cp gs://newzet-dev-st/newrelic.jar ./newrelic/newrelic.jar
+          gsutil cp gs://newzet-dev-st/newrelic.yml ./newrelic/newrelic.yml
+
+      - name: Gradle Caching
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: 🏗️ Build with Gradle
+        run: ./gradlew build
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DEV_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DEV_DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t $IMAGE_NAME:latest --build-arg JAR_FILE=build/libs/*.jar .
+          docker push $IMAGE_NAME:latest
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
+
+      - name: Deploy to VM
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.DEV_SSH_USER }}@${{ secrets.DEV_SSH_HOST }} \
+            "cd /home/jiho99322/app && bash ./deploy.sh ${{ github.sha }}"

--- a/.github/workflows/dev_ci_cd.yml
+++ b/.github/workflows/dev_ci_cd.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      IMAGE_NAME: easyho3/newzet-spring-server
+      IMAGE_NAME: ${{ secrets.DEV_DOCKERHUB_USERNAME }}/newzet-spring-server
 
     steps:
       - name: Checkout code

--- a/.github/workflows/dev_ci_cd.yml
+++ b/.github/workflows/dev_ci_cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - Deploy/issue-#109
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/dev_ci_cd.yml
+++ b/.github/workflows/dev_ci_cd.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build and Deploy To Dev Environment
 
 on:
   push:
@@ -49,7 +49,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: 🏗️ Build with Gradle
+      - name: Build with Gradle
         run: ./gradlew build
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
# 개요
dev 브랜치용 dev서버 연결 및 CI/CD

# 배경
개발용 서버 구축 및 개발용 DB에 대한 필요성을 느껴 회의결과 추가하기로 결정

# 변경된 점
- GCP 기반 배포
- Redis는 vm 내부 배포
- db는 supabase 사용 (현재 개인 supabase, 이후 변경 가능)
- 뉴렐릭은 gcs를 활용하여 다운 (현재 개인 뉴렐릭 파일 사용, 이후 변경 가능)
- dev에 push or merge할경우 자동 배포

## 참고자료
<img width="1109" height="494" alt="image" src="https://github.com/user-attachments/assets/21423acb-0dc0-46f5-a90b-8032961d319d" />

정상 배포 확인 완료

배포 링크 : http://www.backapi.site/swagger-ui/index.html

## 관련 이슈
close #109