### PR TITLE
Subscription API 수정

### DIFF
--- a/src/main/java/com/newzet/api/common/auth/business/TokenConverter.java
+++ b/src/main/java/com/newzet/api/common/auth/business/TokenConverter.java
@@ -1,6 +1,5 @@
 package com.newzet.api.common.auth.business;
 
-import java.util.Base64;
 import java.util.Date;
 
 import javax.crypto.SecretKey;
@@ -20,7 +19,7 @@ public class TokenConverter {
 	private final SecretKey secretKey;
 
 	public TokenConverter(@Value("${jwt.secret}") String secret) {
-		byte[] keyBytes = Base64.getDecoder().decode(secret);
+		byte[] keyBytes = secret.getBytes();
 		this.secretKey = Keys.hmacShaKeyFor(keyBytes);
 	}
 

--- a/src/main/java/com/newzet/api/subscription/business/service/SubscriptionService.java
+++ b/src/main/java/com/newzet/api/subscription/business/service/SubscriptionService.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.newzet.api.common.util.UuidConverter;
 import com.newzet.api.subscription.business.repository.SubscriptionQueryRepository;
 import com.newzet.api.subscription.business.repository.SubscriptionRepository;
 import com.newzet.api.subscription.domain.Subscription;
@@ -29,7 +28,8 @@ public class SubscriptionService {
 		boolean isSubscribed = subscriptionQueryRepository.isSubscribed(userId, fromDomain,
 			mailingList);
 		if (!isSubscribed) {
-			subscriptionRepository.save(Subscription.create(userId, fromName, fromDomain, mailingList));
+			subscriptionRepository.save(
+				Subscription.create(userId, fromName, fromDomain, mailingList));
 		}
 	}
 
@@ -37,18 +37,17 @@ public class SubscriptionService {
 		List<SubscriptionListWithImageProjection> subscriptionWithImageProjection = subscriptionRepository.getSubscriptionWithImage(
 			userId);
 		List<SubscriptionWithImageResponse> subscriptionWithImageResponseList = subscriptionWithImageProjection.stream()
-			.map(subscription -> new SubscriptionWithImageResponse(subscription.getId(),
-				subscription.getNewsletterName(),
-				subscription.getDomain(), subscription.getImageUrl(), subscription.getStatus(),
-				subscription.getDayOfWeek()))
+			.map(subscription -> new SubscriptionWithImageResponse(subscription.id(),
+				subscription.newsletterName(),
+				subscription.domain(), subscription.imageUrl(), subscription.status(),
+				subscription.dayOfWeek()))
 			.toList();
 
 		return SubscriptionListWithImageResponse.of(subscriptionWithImageResponseList);
 	}
 
-	public void deleteSubscription(String subscriptionId) {
-		UUID convertedSubscriptionId = UuidConverter.convert(subscriptionId);
-		subscriptionRepository.delete(convertedSubscriptionId);
+	public void deleteSubscription(UUID subscriptionId) {
+		subscriptionRepository.delete(subscriptionId);
 	}
 
 	public boolean isSubscribing(UUID userId, String domain, String mailingList) {

--- a/src/main/java/com/newzet/api/subscription/jpa/dto/SubscriptionListWithImageProjection.java
+++ b/src/main/java/com/newzet/api/subscription/jpa/dto/SubscriptionListWithImageProjection.java
@@ -2,16 +2,12 @@ package com.newzet.api.subscription.jpa.dto;
 
 import java.util.UUID;
 
-public interface SubscriptionListWithImageProjection {
-	UUID getId();
-
-	String getNewsletterName();
-
-	String getDomain();
-
-	String getImageUrl();
-
-	String getStatus();
-
-	String getDayOfWeek();
+public record SubscriptionListWithImageProjection(
+	UUID id,
+	String newsletterName,
+	String domain,
+	String imageUrl,
+	String status,
+	String dayOfWeek
+) {
 }

--- a/src/main/java/com/newzet/api/subscription/jpa/repository/SubscriptionJpaQueryRepository.java
+++ b/src/main/java/com/newzet/api/subscription/jpa/repository/SubscriptionJpaQueryRepository.java
@@ -1,12 +1,16 @@
 package com.newzet.api.subscription.jpa.repository;
 
+import static com.newzet.api.newsletter.jpa.entity.QNewsletterEntity.*;
 import static com.newzet.api.subscription.jpa.entity.QSubscriptionEntity.*;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
 
 import com.newzet.api.subscription.business.repository.SubscriptionQueryRepository;
+import com.newzet.api.subscription.jpa.dto.SubscriptionListWithImageProjection;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -29,5 +33,22 @@ public class SubscriptionJpaQueryRepository implements SubscriptionQueryReposito
 						.and(subscriptionEntity.newsletterMailingList.eq(mailingList)))
 			)
 			.fetchFirst() != null;
+	}
+
+	List<SubscriptionListWithImageProjection> getSubscriptionWithImage(UUID userId) {
+		return queryFactory
+			.select(Projections.constructor(SubscriptionListWithImageProjection.class,
+				subscriptionEntity.id,
+				subscriptionEntity.newsletterName,
+				newsletterEntity.domain,
+				newsletterEntity.imageUrl,
+				newsletterEntity.status,
+				newsletterEntity.dayOfWeek
+			))
+			.from(subscriptionEntity)
+			.innerJoin(newsletterEntity)
+			.on(subscriptionEntity.newsletterDomain.eq(newsletterEntity.domain))
+			.where(subscriptionEntity.userId.eq(userId))
+			.fetch();
 	}
 }

--- a/src/main/java/com/newzet/api/subscription/jpa/repository/SubscriptionJpaRepository.java
+++ b/src/main/java/com/newzet/api/subscription/jpa/repository/SubscriptionJpaRepository.java
@@ -1,34 +1,10 @@
 package com.newzet.api.subscription.jpa.repository;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import com.newzet.api.subscription.jpa.dto.SubscriptionListWithImageProjection;
 import com.newzet.api.subscription.jpa.entity.SubscriptionEntity;
 
-import io.lettuce.core.dynamic.annotation.Param;
-
 public interface SubscriptionJpaRepository extends JpaRepository<SubscriptionEntity, UUID> {
-	@Query(value = """
-			SELECT
-			  fs.id,
-			  fs.newsletter_name,
-			  n.domain,
-			  n.image_url,
-			  n.status,
-			  n.day_of_week
-			FROM
-			  (SELECT *
-			  FROM subscriptions s
-			  WHERE s.user_id = :userId
-			  ) fs
-			INNER JOIN
-			  newsletters n
-			ON
-			  fs.newsletter_domain = n.domain
-		""", nativeQuery = true)
-	List<SubscriptionListWithImageProjection> getSubscriptionWithImage(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/newzet/api/subscription/jpa/repository/SubscriptionRepositoryImpl.java
+++ b/src/main/java/com/newzet/api/subscription/jpa/repository/SubscriptionRepositoryImpl.java
@@ -19,16 +19,18 @@ import lombok.RequiredArgsConstructor;
 public class SubscriptionRepositoryImpl implements SubscriptionRepository {
 
 	private final SubscriptionJpaRepository subscriptionJpaRepository;
+	private final SubscriptionJpaQueryRepository subscriptionJpaQueryRepository;
 
 	@Override
 	public Subscription save(Subscription subscription) {
 		SubscriptionEntity subscriptionEntity = SubscriptionEntityMapper.toEntity(subscription);
-		return SubscriptionEntityMapper.toDomain(subscriptionJpaRepository.save(subscriptionEntity));
+		return SubscriptionEntityMapper.toDomain(
+			subscriptionJpaRepository.save(subscriptionEntity));
 	}
 
 	@Override
 	public List<SubscriptionListWithImageProjection> getSubscriptionWithImage(UUID userId) {
-		return subscriptionJpaRepository.getSubscriptionWithImage(userId);
+		return subscriptionJpaQueryRepository.getSubscriptionWithImage(userId);
 	}
 
 	@Override

--- a/src/main/java/com/newzet/api/subscription/presentation/controller/SubscriptionController.java
+++ b/src/main/java/com/newzet/api/subscription/presentation/controller/SubscriptionController.java
@@ -1,5 +1,7 @@
 package com.newzet.api.subscription.presentation.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.newzet.api.common.auth.annotation.Login;
+import com.newzet.api.common.auth.annotation.RequireAuth;
 import com.newzet.api.common.auth.domain.AuthUser;
 import com.newzet.api.common.response.ResponseCode;
 import com.newzet.api.common.response.SuccessResponse;
@@ -29,6 +32,7 @@ public class SubscriptionController {
 	@GetMapping
 	@Operation(summary = "뉴스레터 구독 목록 조회",
 		description = "유저의 뉴스레터 구독 목록을 조회한다.")
+	@RequireAuth
 	public ResponseEntity<SuccessResponse<SubscriptionListWithImageResponse>> getSubscriptionList(
 		@Login AuthUser authUser) {
 		SubscriptionListWithImageResponse subscriptionListWithImage = subscriptionService.getSubscriptionWithImage(
@@ -43,8 +47,9 @@ public class SubscriptionController {
 	@DeleteMapping("/{subscriptionId}")
 	@Operation(summary = "뉴스레터 구독 삭제",
 		description = "유저의 뉴스레터 구독을 삭제한다.")
+	@RequireAuth
 	public ResponseEntity<SuccessResponse<String>> deleteSubscription(
-		@PathVariable String subscriptionId) {
+		@PathVariable UUID subscriptionId) {
 		subscriptionService.deleteSubscription(subscriptionId);
 		SuccessResponse<String> response = SuccessResponse.create(
 			ResponseCode.SUCCESS, "뉴스레터 구독 삭제 성공", "empty");

--- a/src/test/java/com/newzet/api/common/auth/business/TokenConverterTest.java
+++ b/src/test/java/com/newzet/api/common/auth/business/TokenConverterTest.java
@@ -51,7 +51,7 @@ class TokenConverterTest {
 		static final UUID USER_ID = UUID.randomUUID();
 		static final String RAW_SECRET = "testsecretkeymustbelongerthan256bitstomakeitwork00000";
 		static final String SECRET = Base64.getEncoder().encodeToString(RAW_SECRET.getBytes());
-		static final SecretKey SECRET_KEY = Keys.hmacShaKeyFor(RAW_SECRET.getBytes());
+		static final SecretKey SECRET_KEY = Keys.hmacShaKeyFor(SECRET.getBytes());
 		static final Date PAST = new Date(
 			((System.currentTimeMillis() - 60 * 60 * 1000) / 1000) * 1000);
 		static final Date FUTURE = new Date(

--- a/src/test/java/com/newzet/api/subscription/jpa/SubscriptionRepositoryImplTest.java
+++ b/src/test/java/com/newzet/api/subscription/jpa/SubscriptionRepositoryImplTest.java
@@ -12,11 +12,13 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import com.newzet.api.config.PostgresTestContainerConfig;
+import com.newzet.api.config.db.QuerydslConfig;
 import com.newzet.api.subscription.domain.Subscription;
+import com.newzet.api.subscription.jpa.repository.SubscriptionJpaQueryRepository;
 import com.newzet.api.subscription.jpa.repository.SubscriptionRepositoryImpl;
 
 @DataJpaTest
-@Import({SubscriptionRepositoryImpl.class})
+@Import({SubscriptionRepositoryImpl.class, QuerydslConfig.class, SubscriptionJpaQueryRepository.class})
 @ExtendWith({PostgresTestContainerConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class SubscriptionRepositoryImplTest {


### PR DESCRIPTION
# 개요

- Subscritpion 에러 수정

# 배경

- 플러터에서 실제 API를 호출하는 과정에서 발생하는 에러를 해결

# 변경된 점
- Subscripiton API
  - RequireAuth 명시
  - UUIDConverter 제거
  - 하드코딩된 쿼리, Querydsl로 수정
  - null 값 equal 조건에 들어갈 수 있음
  

## 참고자료
<img width="648" height="210" alt="스크린샷 2025-08-24 오후 2 43 00" src="https://github.com/user-attachments/assets/a6ed17aa-eb00-4994-86ea-acc312d61bfe" />


## 관련 이슈

close #111
