### PR TITLE
Hotfix: FCM Token 관련 엔드포인트에 @RequireAuth 추가

### DIFF
--- a/src/main/java/com/newzet/api/fcm/api/FcmTokenApi.java
+++ b/src/main/java/com/newzet/api/fcm/api/FcmTokenApi.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.newzet.api.common.auth.annotation.Login;
+import com.newzet.api.common.auth.annotation.RequireAuth;
 import com.newzet.api.common.auth.domain.AuthUser;
 import com.newzet.api.common.response.SuccessResponse;
 import com.newzet.api.fcm.api.dto.FcmTokenDeleteRequest;
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 @RequestMapping("/api/v1/fcm")
+@RequireAuth
 @Tag(name = "FCM 토큰 관리", description = "FCM 토큰 관련 API")
 public interface FcmTokenApi {
 


### PR DESCRIPTION
# 개요
FCM Token 관련 엔드포인트에 @RequireAuth 추가

# 배경
FCM Token 관련 엔드포인트에 @RequireAuth 부재

# 변경된 점
- FCM Token 관련 엔드포인트에 @RequireAuth 추가

## 참고자료
x

## 관련 이슈

close #119 
