### PR TITLE
Hotfix: newsletter 조회 조건 prefix로 올바르게 수정

### DIFF
--- a/src/main/java/com/newzet/api/newsletter/jpa/repository/NewsletterJpaRepository.java
+++ b/src/main/java/com/newzet/api/newsletter/jpa/repository/NewsletterJpaRepository.java
@@ -11,7 +11,7 @@ import com.newzet.api.newsletter.jpa.entity.NewsletterEntity;
 
 public interface NewsletterJpaRepository extends JpaRepository<NewsletterEntity, UUID> {
 
-	List<NewsletterEntity> findNewsletterListByName(String name);
+	List<NewsletterEntity> findNewsletterListByNameStartingWith(String name);
 
 	List<NewsletterEntity> findNewsletterListByCategoryId(UUID categoryId);
 

--- a/src/main/java/com/newzet/api/newsletter/jpa/repository/NewsletterRepositoryImpl.java
+++ b/src/main/java/com/newzet/api/newsletter/jpa/repository/NewsletterRepositoryImpl.java
@@ -28,7 +28,7 @@ public class NewsletterRepositoryImpl implements NewsletterRepository {
 
 	@Override
 	public List<Newsletter> findNewsLetterListByName(String name) {
-		return jpaRepository.findNewsletterListByName(name).stream()
+		return jpaRepository.findNewsletterListByNameStartingWith(name).stream()
 			.map(NewsletterEntityMapper::toDomain)
 			.toList();
 	}


### PR DESCRIPTION
# 개요

- newsletter 조회 조건 prefix로 올바르게 수정

# 배경



# 변경된 점



## 참고자료



## 관련 이슈

close #121 
