### PR TITLE
@RequireAuth 커스텀 어노테이션 위치 구현체로 변경

### DIFF
--- a/src/main/java/com/newzet/api/fcm/api/FcmTokenApi.java
+++ b/src/main/java/com/newzet/api/fcm/api/FcmTokenApi.java
@@ -6,31 +6,30 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.newzet.api.common.auth.annotation.Login;
-import com.newzet.api.common.auth.annotation.RequireAuth;
 import com.newzet.api.common.auth.domain.AuthUser;
 import com.newzet.api.common.response.SuccessResponse;
 import com.newzet.api.fcm.api.dto.FcmTokenDeleteRequest;
 import com.newzet.api.fcm.api.dto.FcmTokenUpsertRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 @RequestMapping("/api/v1/fcm")
-@RequireAuth
 @Tag(name = "FCM 토큰 관리", description = "FCM 토큰 관련 API")
 public interface FcmTokenApi {
 
 	@PostMapping("/token")
 	@Operation(summary = "fcm 토큰 갱신 or 추가",
 		description = "신규 FCM 토큰을 저장한다.")
-	SuccessResponse<Object> createFcmToken(@Login AuthUser authUser,
+	SuccessResponse<Object> createFcmToken(@Parameter(hidden = true) @Login AuthUser authUser,
 		@Valid @RequestBody FcmTokenUpsertRequest request);
 
 	@DeleteMapping("/token")
 	@Operation(summary = "fcm 토큰 삭제",
 		description = "신규 FCM 토큰을 삭제한다.")
 	SuccessResponse<Object> deleteFcmToken(
-		@Login AuthUser authUser,
+		@Parameter(hidden = true) @Login AuthUser authUser,
 		@Valid @RequestBody FcmTokenDeleteRequest request);
 }

--- a/src/main/java/com/newzet/api/fcm/controller/FcmTokenController.java
+++ b/src/main/java/com/newzet/api/fcm/controller/FcmTokenController.java
@@ -2,6 +2,7 @@ package com.newzet.api.fcm.controller;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import com.newzet.api.common.auth.annotation.RequireAuth;
 import com.newzet.api.common.auth.domain.AuthUser;
 import com.newzet.api.common.response.ResponseCode;
 import com.newzet.api.common.response.SuccessResponse;
@@ -14,16 +15,19 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequireAuth
 public class FcmTokenController implements FcmTokenApi {
 
 	private final FcmTokenOrchestrator fcmTokenOrchestrator;
 
-	public SuccessResponse<Object> createFcmToken(AuthUser authUser, FcmTokenUpsertRequest request) {
+	public SuccessResponse<Object> createFcmToken(AuthUser authUser,
+		FcmTokenUpsertRequest request) {
 		fcmTokenOrchestrator.upsertFcmToken(authUser.getId(), request.fcmToken());
 		return SuccessResponse.create(ResponseCode.SUCCESS, "fcm 토큰 저장 성공", null);
 	}
 
-	public SuccessResponse<Object> deleteFcmToken(AuthUser authUser, FcmTokenDeleteRequest request) {
+	public SuccessResponse<Object> deleteFcmToken(AuthUser authUser,
+		FcmTokenDeleteRequest request) {
 		fcmTokenOrchestrator.deleteFcmToken(authUser.getId(), request.fcmToken());
 		return SuccessResponse.create(
 			ResponseCode.SUCCESS, "fcm 토큰 삭제 성공", null);


### PR DESCRIPTION
# 개요
@RequireAuth 커스텀 어노테이션 위치 구현체로 변경

# 배경
@RequireAuth 커스텀 어노테이션 위치가 포트에 있어 적용이 안되는 문제 발생

# 변경된 점
- @RequireAuth 커스텀 어노테이션 위치 구현체로 변경
- @Login에 swagger parameter hidden 설정

## 참고자료
x

## 관련 이슈
close #128 
