### PR TITLE
MailController request 로깅 추가

### DIFF
--- a/src/main/java/com/newzet/api/mail/presentation/MailController.java
+++ b/src/main/java/com/newzet/api/mail/presentation/MailController.java
@@ -12,11 +12,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/functions/v1/mail")
 @Tag(name = "메일", description = "메일 관련 API")
+@Slf4j
 public class MailController {
 
 	private final MailServiceFacade mailServiceFacade;
@@ -24,8 +26,10 @@ public class MailController {
 	@PostMapping
 	@Operation(summary = "메일 수신", description = "메일을 수신하며 전달받은 메타데이터를 기반으로 뉴스레터 및 구독 관련 로직을 처리한다.")
 	public ResponseEntity<Object> receive(@RequestBody @Valid MailMetadataDto metadata) {
+		log.info("✅ Mail received. metadata: {}", metadata);
 		mailServiceFacade.processMail(metadata.getFromName(), metadata.getFromDomain(),
-			metadata.getToDomain(), metadata.getMailingList(), metadata.getHtmlLink(), metadata.getTitle());
+			metadata.getToDomain(), metadata.getMailingList(), metadata.getHtmlLink(),
+			metadata.getTitle());
 		return ResponseEntity.ok().build();
 	}
 }


### PR DESCRIPTION
# 개요

- 카카오 소셜 로그인 기능 추가를 위한 PR

# 배경

- 해당 업무를 수행하게 된 배경

# 변경된 점

- 카카오 인증서버로 사용자 정보 요청 기능 추가
- 사용자 정보 데이터베이스 저장

## 참고자료

- 리뷰어의 이해를 돕기 위한 이미지, 링크, Diagram 파일 추가

## 관련 이슈

close #130