### PR TITLE
mail title decode 로직 추가

### DIFF
--- a/src/main/java/com/newzet/api/mail/business/MailServiceFacade.java
+++ b/src/main/java/com/newzet/api/mail/business/MailServiceFacade.java
@@ -1,5 +1,7 @@
 package com.newzet.api.mail.business;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -30,7 +32,11 @@ public class MailServiceFacade {
 			mailingList);
 		NewsletterImageUrlCacheDto imageUrlCacheDto = newsletterImageUrlService.findByDomainOrMailingList(
 			fromName, mailingList);
-		articleService.saveArticleBatch(userId, fromName, fromDomain, mailingList, imageUrlCacheDto.imageUrl(), htmlLink, title);
+
+		byte[] decodedBytes = Base64.getDecoder().decode(title);
+		String decodedTitle = new String(decodedBytes, StandardCharsets.UTF_8);
+		articleService.saveArticleBatch(userId, fromName, fromDomain, mailingList,
+			imageUrlCacheDto.imageUrl(), htmlLink, decodedTitle);
 
 		//TODO: 아티클 저장 후 배치처리 된 애들에 대해서 별도로 event 형식으로 fcm noti 보내는거 추가 (여기 말고)
 	}

--- a/src/main/java/com/newzet/api/mail/presentation/MailController.java
+++ b/src/main/java/com/newzet/api/mail/presentation/MailController.java
@@ -26,7 +26,6 @@ public class MailController {
 	@PostMapping
 	@Operation(summary = "메일 수신", description = "메일을 수신하며 전달받은 메타데이터를 기반으로 뉴스레터 및 구독 관련 로직을 처리한다.")
 	public ResponseEntity<Object> receive(@RequestBody @Valid MailMetadataDto metadata) {
-		log.info("✅ Mail received. metadata: {}", metadata);
 		mailServiceFacade.processMail(metadata.getFromName(), metadata.getFromDomain(),
 			metadata.getToDomain(), metadata.getMailingList(), metadata.getHtmlLink(),
 			metadata.getTitle());


### PR DESCRIPTION
# 개요

- mail title decode 로직 추가

# 배경

- 해당 업무를 수행하게 된 배경

# 변경된 점

- 카카오 인증서버로 사용자 정보 요청 기능 추가
- 사용자 정보 데이터베이스 저장

## 참고자료

- 리뷰어의 이해를 돕기 위한 이미지, 링크, Diagram 파일 추가

## 관련 이슈

close #(이슈번호) #(이슈번호)
