### PR TITLE
email이 null일 경우 email 수정안하도록 변경

### DIFF
--- a/src/main/java/com/newzet/api/userinfo/domain/Userinfo.java
+++ b/src/main/java/com/newzet/api/userinfo/domain/Userinfo.java
@@ -17,6 +17,9 @@ public class Userinfo {
 	private LocalDateTime deletedAt;
 
 	public void changeEmail(String email) {
+		if (email == null) {
+			return;
+		}
 		this.email = email.trim();
 	}
 

--- a/src/test/java/com/newzet/api/userinfo/domain/UserinfoTest.java
+++ b/src/test/java/com/newzet/api/userinfo/domain/UserinfoTest.java
@@ -1,0 +1,80 @@
+package com.newzet.api.userinfo.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.Assertions.*;
+import java.util.UUID;
+import java.time.LocalDateTime;
+
+class UserinfoTest {
+
+    private Userinfo userinfo;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        userinfo = new Userinfo(
+                userId,
+                "test@example.com",
+                "testNickname",
+                UserRole.MEMBER,
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    @Test
+    @DisplayName("이메일 변경 - 정상 케이스")
+    void changeEmail_withValidEmail() {
+        // given
+        String newEmail = "  new@example.com  ";
+
+        // when
+        userinfo.changeEmail(newEmail);
+
+        // then
+        assertThat(userinfo.getEmail()).isEqualTo("new@example.com");
+    }
+
+    @Test
+    @DisplayName("이메일 변경 - null인 경우")
+    void changeEmail_withNull() {
+        // given
+        String originalEmail = userinfo.getEmail();
+
+        // when
+        userinfo.changeEmail(null);
+
+        // then
+        assertThat(userinfo.getEmail()).isEqualTo(originalEmail);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 테스트")
+    void changeNickname() {
+        // given
+        String newNickname = "  newNickname  ";
+
+        // when
+        userinfo.changeNickname(newNickname);
+
+        // then
+        assertThat(userinfo.getNickname()).isEqualTo("newNickname");
+    }
+
+    @Test
+    @DisplayName("사용자 삭제 테스트")
+    void delete() {
+        // given
+        assertThat(userinfo.getDeletedAt()).isNull();
+
+        // when
+        userinfo.delete();
+
+        // then
+        assertThat(userinfo.getDeletedAt()).isNotNull();
+        assertThat(userinfo.getDeletedAt()).isBeforeOrEqualTo(LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
# 개요
유저 정보 수정 오류 해결

# 배경
email이 null일 경우에 수정 안하는 로직이 필요

# 변경된 점
- email이 null일 경우에 수정 안하도록 변경

## 참고자료
x

## 관련 이슈

close #133 
