### PR TITLE
아티클 반환 시 Service/Domain 레이어에서 created_at KST로 변환하도록 수정

### DIFF
--- a/src/main/java/com/newzet/api/article/business/dto/ArticleEntityDto.java
+++ b/src/main/java/com/newzet/api/article/business/dto/ArticleEntityDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.newzet.api.article.domain.Article;
+import com.newzet.api.common.util.UtcTimeZoneConverter;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -56,8 +57,8 @@ public class ArticleEntityDto {
 			isRead,
 			isLike,
 			isShare,
-			createdAt,
-			deletedAt
+			UtcTimeZoneConverter.toKst(createdAt),
+			UtcTimeZoneConverter.toKst(deletedAt)
 		);
 	}
 }

--- a/src/main/java/com/newzet/api/article/controller/ArticleController.java
+++ b/src/main/java/com/newzet/api/article/controller/ArticleController.java
@@ -52,7 +52,7 @@ public class ArticleController {
 	}
 
 	@GetMapping("/{articleId}")
-	// @RequireAuth
+	@RequireAuth
 	@Operation(summary = "아티클 단건 조회",
 		description = "유저가 구독한 뉴스레터의 아티클을 조회한다.")
 	public ResponseEntity<SuccessResponse<ArticleContentResponse>> getArticle(

--- a/src/main/java/com/newzet/api/article/controller/dto/ArticleDetailResponse.java
+++ b/src/main/java/com/newzet/api/article/controller/dto/ArticleDetailResponse.java
@@ -3,6 +3,8 @@ package com.newzet.api.article.controller.dto;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.newzet.api.common.util.UtcTimeZoneConverter;
+
 public record ArticleDetailResponse(
 	String id,
 	String newsletterName,
@@ -15,7 +17,7 @@ public record ArticleDetailResponse(
 	public static ArticleDetailResponse of(UUID id, String newsletterName, String newsletterImgUrl,
 		String title, boolean isRead, LocalDateTime createdAt) {
 		return new ArticleDetailResponse(id.toString(), newsletterName, newsletterImgUrl, title,
-			isRead, createdAt.toString());
+			isRead, UtcTimeZoneConverter.toKst(createdAt).toString());
 	}
 
 	public int getDay() {

--- a/src/main/java/com/newzet/api/common/util/UtcTimeZoneConverter.java
+++ b/src/main/java/com/newzet/api/common/util/UtcTimeZoneConverter.java
@@ -1,0 +1,19 @@
+package com.newzet.api.common.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public class UtcTimeZoneConverter {
+
+	private static final ZoneId UTC = ZoneId.of("UTC");
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	public static LocalDateTime toKst(LocalDateTime utcDateTime) {
+		if (utcDateTime == null) {
+			return null;
+		}
+		return utcDateTime.atZone(UTC)
+			.withZoneSameInstant(KST)
+			.toLocalDateTime();
+	}
+}


### PR DESCRIPTION
# 개요

- 아티클 반환 시 Service/Domain 레이어에서 created_at KST로 변환하도록 수정

# 배경

- 

# 변경된 점

- UTC를 KST로 변경하는 유틸 클래스 UtcTimeZoneConverter 정의
- DTO 혹은 도메인 객체 생성 시 해당 유틸 메서드 사용하여 KST로 변환하도록 수정

## 참고자료

- DB에 저장된 created_at (UTC 기준)
<img width="1186" height="84" alt="스크린샷 2025-10-03 오후 6 14 02" src="https://github.com/user-attachments/assets/aa7185bb-1869-42db-af3b-7977e7c5d203" />

- 실제 API 반환 created_at(KST 변환, UTC+09:00)
<img width="916" height="422" alt="스크린샷 2025-10-03 오후 6 14 13" src="https://github.com/user-attachments/assets/538b6746-93cc-4018-a84b-27e43f528d34" />

## 관련 이슈

close #140
